### PR TITLE
Use chordpro CLI for builds

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,133 +1,26 @@
-# pdflatex has trouble with lithium.chopro.html
-# take_it_easy.chopro.html isn't done yet
-# give_a_little_bit.chopro.html isnt done yet
+# Simple Makefile to build HTML and PDF versions of songs using chordpro
 
-KC_SONGS = \
-    amie.chopro.html \
-    and_she_was.chopro.html \
-    badfish.chopro.html \
-    big_yellow_taxi.chopro.html \
-    clocks.chopro.html \
-    comfortably_numb.chopro.html \
-    coming_up_close.chopro.html \
-    cruel_to_be_kind.chopro.html \
-    dead_flowers.chopro.html \
-    down_under.chopro.html \
-    eight_days_a_week.chopro.html \
-    flagpole_sitta.chopro.html \
-    folsom_prison_blues.chopro.html \
-    gold_dust_woman.chopro.html \
-    heart_of_gold.chopro.html \
-    high_and_dry.chopro.html \
-    horse.chopro.html \
-    horse_with_no_name.chopro.html \
-    hotel_california.chopro.html \
-    island_in_the_sun.chopro.html \
-    wish_it_would_rain.chopro.html \
-    jumper.chopro.html \
-    last_train_to_clarksville.chopro.html \
-    learning_to_fly.chopro.html \
-    long_ride_home.chopro.html \
-    mary_janes_last_dance.chopro.html \
-    my_sweet_annette.chopro.html \
-    no_rain.chopro.html \
-    one.chopro.html \
-    peaceful_easy_feeling.chopro.html \
-    ring_of_fire.chopro.html \
-    salty_south.chopro.html \
-    service_and_repair.chopro.html \
-    soul_meets_body.chopro.html \
-    southern_cross.chopro.html \
-    stuck_in_the_middle_with_you.chopro.html \
-    sundown.chopro.html \
-    walk_on_the_ocean.chopro.html \
-    wasted_on_the_way.chopro.html \
-    we_can_work_it_out.chopro.html \
-    wish_you_were_here.chopro.html \
-    with_a_little_help_from_my_friends.chopro.html \
-    yer_so_bad.chopro.html \
-    $(NULL)
+SONG_SRC := $(wildcard songs/*.cho)
+SONG_HTML := $(patsubst songs/%.cho, build/%.html, $(SONG_SRC))
+SONG_PDF := $(patsubst songs/%.cho, build/%.pdf, $(SONG_SRC))
+SONGBOOK := kc_songbook.pdf
 
-JC_SONGS = \
-    amie.chopro.html \
-    and_she_was.chopro.html \
-    badfish.chopro.html \
-    christians_and_pagans.chopro.html \
-    clocks.chopro.html \
-    comfortably_numb.chopro.html \
-    coming_up_close.chopro.html \
-    crazy_on_you.chopro.html \
-    cruel_to_be_kind.chopro.html \
-    dead_flowers.chopro.html \
-    donald_wheres_your_trousers.chopro.html \
-    down_by_the_river.chopro.html \
-    down_under.chopro.html \
-    eight_days_a_week.chopro.html \
-    flagpole_sitta.chopro.html \
-    folsom_prison_blues.chopro.html \
-    gold_dust_woman.chopro.html \
-    heart_of_gold.chopro.html \
-    hey_there_delilah.chopro.html \
-    high_and_dry.chopro.html \
-    horse.chopro.html \
-    horse_with_no_name.chopro.html \
-    hotel_california.chopro.html \
-    in_between_days.chopro.html \
-    island_in_the_sun.chopro.html \
-    wish_it_would_rain.chopro.html \
-    jumper.chopro.html \
-    last_train_to_clarksville.chopro.html \
-    learning_to_fly.chopro.html \
-    let_her_cry.chopro.html \
-    lola.chopro.html \
-    long_ride_home.chopro.html \
-    man_of_constant_sorrow.chopro.html \
-    mary_janes_last_dance.chopro.html \
-    my_sweet_annette.chopro.html \
-    no_rain.chopro.html \
-    one.chopro.html \
-    peaceful_easy_feeling.chopro.html \
-    ring_of_fire.chopro.html \
-    salty_south.chopro.html \
-    service_and_repair.chopro.html \
-    soul_meets_body.chopro.html \
-    southern_cross.chopro.html \
-    stuck_in_the_middle_with_you.chopro.html \
-    summer_of_69.chopro.html \
-    sundown.chopro.html \
-    sweet_child_of_mine.chopro.html \
-    walk_on_the_ocean.chopro.html \
-    wasted_on_the_way.chopro.html \
-    we_can_work_it_out.chopro.html \
-    wish_you_were_here.chopro.html \
-    with_a_little_help_from_my_friends.chopro.html \
-    wonderwall.chopro.html \
-    yer_so_bad.chopro.html \
-    $(NULL)
+.PHONY: all clean
 
-    # lithium.chopro.html \
+all: $(SONG_HTML) $(SONG_PDF) $(SONGBOOK)
 
-all: jc_songbook.pdf kc_songbook.pdf
+build:
+	mkdir -p build
+
+build/%.pdf: songs/%.cho | build
+	chordpro -o $@ $<
+
+build/%.html: songs/%.cho | build
+	chordpro -o $@ $<
+
+
+$(SONGBOOK): $(SONG_SRC)
+	chordpro -o $@ $^
 
 clean:
-	rm -f jc_songbook.pdf kc_songbook.pdf
-
-jc_songbook.chopro: $(JC_SONGS)
-	for i in $^ ; do echo "$$i" ; done | tools/html2guitartex "Jamcrowd Songbook" jc_songbook.chopro
-
-jc_songbook.pdf: jc_songbook.chopro
-	gtx2tex jc_songbook.chopro
-	LC_ALL=C sed -i "" -e 's/gchord{/chord{/g' jc_songbook.tex
-	pdflatex jc_songbook.tex
-        makeindex kc_songbook.idx
-	pdflatex jc_songbook.tex
-
-kc_songbook.chopro: $(KC_SONGS)
-	for i in $^ ; do echo "$$i" ; done | tools/html2guitartex "Jamcrowd Songbook, Karma Chickens Edition" kc_songbook.chopro
-
-kc_songbook.pdf: kc_songbook.chopro
-	gtx2tex kc_songbook.chopro
-	LC_ALL=C sed -i "" -e 's/gchord{/chord{/g' kc_songbook.tex
-	pdflatex kc_songbook.tex
-        makeindex kc_songbook.idx
-	pdflatex kc_songbook.tex
+	rm -rf build

--- a/README.md
+++ b/README.md
@@ -1,30 +1,18 @@
-This is a collection of some of the songs played used by the Jamcrowd.
+This is a collection of some of the songs used by the Jamcrowd.
 
-The songs are in ChordPro format, embedded in HTML.
+The songs are stored in `songs/` as [ChordPro](https://www.chordpro.org/chordpro/) files (`.cho`).
 
-The HTML files reference some Javascript developed by Don Mahurin to reformat the ChordPro as HTML.
+# Creating HTML or PDF
 
-jc_songbook.pdf is the Jamcrowd version.  This is slightly longer and contains some songs we like to play in the Jamcrowd that other groups may not know.
+## Prerequisites
 
-kc_songbook.pdf is the songbook that the Karma Chickens used to play at Burning man, and any random group of people may be more likely to know.
+* [`chordpro`](https://www.chordpro.org/) CLI tool.
 
-# Creating a PDF book
+## Building
 
-## Prerequisites:
+Run `make` to generate HTML and PDF versions of all songs. The per-song files
+will be written to the `build/` directory and a combined songbook will be
+written to `kc_songbook.pdf`. Individual songs can be generated with, e.g.,
+`make build/horse_with_no_name.pdf` or `make build/horse_with_no_name.html`.
 
-* `pdflatex` - I was able to install this on macOS through the `texlive-latex` port.
-* `makeindex` - I was able to install this on macOS through the `texlive-basic` port.
-* `titlepic.sty` - I've also vendored a copy in tools/ but you'll have to manage installing that yourself.
-* `gchords.sty` - I'm using 1.21, available from https://kasper.phi-sci.com/gchords/.  I've also vendored a copy in tools/ but you'll have to manage installing that yourself.
-* `gtx2tex` - This can be installed from https://sourceforge.net/projects/guitartex/files/GuitarTeX/GuitarTeX-2.8.2/
-
-(GuitarTeX 2.8.2 is more than 20 years old and very fragile.  If you have trouble getting it to run, you may have some luck by instead using the Docker image from https://github.com/SickHub/docker-texlive-guitartex, but you're probably going to have to wing it.  RUN_IN_CONTAINER has the commands using `podman` to execute `gtx2tex` and then `pdflatex` inside the image.)
-
-## Building the PDF
-
-* `make jc_songbook.pdf` to generate the Jamcrowd version.
-* `make kc_songbook.pdf` to generate the Karma Chickens version.
-
-(The Makefile is also very fragile and needs revamping.)
-
-Good luck!
+The build process now runs in a single step using the `chordpro` command.

--- a/songs/amie.cho
+++ b/songs/amie.cho
@@ -1,0 +1,59 @@
+
+{even}
+{t:Amie}
+{st:Pure Prarie League}
+
+[A](intro riff)
+[A] (intro)       [G]      [D]
+[A] (intro)       [G]      [D]
+
+[A]I can see why [G]you think [D]you be[A]long to me. [G] [D]
+[A]I never tried to [G]make you [D]think or [A]let you see [G]one thing [D]for yourself.
+But now you're [C]off with someone else and I'm a[D]lone.
+You see I [C]thought that I might keep you for my [E]own.
+
+[A]Amie, [G]what you wanna [D]do?  [A]I think [G]I could stay with [D]you
+for a [Bm]while, maybe longer if I [E]do.
+
+[A]     [G]     [D]     [A]     [G]     [D]
+
+[A]Don't you think the [G]time is [D]right for [A]us to find [G] [D]
+[A]All the things we [G]thought weren't [D]proper [A]could be right in time, 
+And can you [D]see, which way [C]we should turn together or a[D]lone?
+I can [C]never see what's right or what is[E] wrong!  (Will it take too long to see?)
+
+[A]Amie, [G]what you wanna [D]do?  [A]I think [G]I could stay with [D]you
+for a [Bm]while, maybe longer if I [E]do.
+
+[A]     [G]     [D]     [A]     [G]     [D]
+
+[A] (solo [G] over [D] verse [A] chords) [G]     [D]
+[A]     [G]     [D]     [A]     [A]     [A]
+[D]     [C]     [E]
+
+[A]Amie, [G]what you wanna [D]do?  [A]I think [G]I could stay with [D]you
+for a [Bm]while, maybe longer if I [E]do.
+
+[A]     [G]     [D]
+
+[A]Now it's come to [G]what you [D]want, you've [A]had your way. [G] [D]
+And [A]all the things you [G]thought bef[D]ore just [A]faded into gray
+And can you [D]see that I [C]don't know if it's you or if it's [D]me.
+If it's [C]one of us, I'm sure we both will [E]see.  Won't you look at me and tell me?
+
+[A]Amie, [G]what you wanna [D]do?  [A]I think [G]I could stay with [D]you
+for a [Bm]while, maybe longer if I [E]do. (longer if I do!)
+
+[A]Amie, [G]what you wanna [D]do?  [A]I think [G]I could stay with [D]you
+for a [Bm]while, maybe longer if I [E]do.
+
+{comment: soft picking:}
+
+I keep [A]falling in and out of [G]love with [D]you.
+[A]Falling in and out of [G]love with [D]you.
+[A]Don't know what I'm gonna [G]do[D].
+I keep [A]falling in and out of [G]love with [Fm]youuuuuuu.
+
+{comment: end on A}
+
+

--- a/songs/and_she_was.cho
+++ b/songs/and_she_was.cho
@@ -1,0 +1,65 @@
+
+{t:And She Was}
+{st:Talking Heads}
+
+Intro:
+[E] [A] [E] [E] [A] [E]
+
+[E]And she was [A]lying in the [E]grass
+[E]And she could [A]hear the highway [E]breathing
+[E]And she could [A]see a nearby [E]factory
+[E]She's making [A]sure she is not [E]dreaming
+[Bb]See the [F]lights of the [C]neighbor's [F]house
+[Bb]Now she's [C]starting to [F]rise
+[Bb]Take a [F]minute to [C]concen[F]trate
+[Bb]And she opens [G]up her[C] eyes
+
+[E]The world was [A]moving, she was [D]right there [A]with it
+And she [E]was     [A]     [D]     [A]
+[E]The world was [A]moving she was [D]floating a[A]bove it
+And she [E]was     [A]     [D]     [A]
+
+[E]And she was [A]drifting through the [E]backyard
+[E]And she was [A]taking off her [E]dress
+[E]And she was [A]moving very [E]slowly
+[E]Rising [A]up above the [E]earth
+[Bb]Moving [F]into the [C]uni[F]verse
+[Bb] Drifting [C] this way and [F]that
+[Bb]Now [F]touching the [C]ground at [F]all
+[Bb]Up a[G]bove the [C]yard
+
+{colb}
+[E]The world was [A]moving, she was [D]right there [A]with it
+And she [E]was     [A]     [D]     [A]
+[E]The world was [A]moving she was [D]floating a[A]bove it
+And she [E]was     [A]     [D]     [A]
+
+She was [Bm]glad about it ... no doubt about it
+[G]She isn't sure about where she's gone
+[Bm]No time to think about what to tell them
+[G]No time to think about what she's done
+And she [E]was   [A]     [E]
+
+[E]And she was [A]looking at her[E]self
+[E]And things were [A]looking like a [E]movie
+[E]She had a [A] pleasant ele[E]vation
+[E]She's moving [A]out in all di[E]rections
+
+[Bb]Hey [F]Hey [C]Hey Hey [F]Hey
+[Bb]Hey [C]Hey [F]Hey
+[Bb]Hey [F]Hey [C]Hey Hey [F]Hey
+[Bb]Hey [G]Hey [C]Hey
+#[Bb]Oh, [F]oh, [C]oh, [F]...
+#[Bb]Oh, [C]oh, [F]oh, ...
+#[Bb]Oh, [F]oh, [C]oh, [F]...
+#[Bb]Oh, [G]oh, [C]oh, ...
+
+[E]The world was [A]moving, she was [D]right there [A]with it
+And she [E]was     [A]     [D]     [A]
+[E]The world was [A]moving she was [D]floating a[A]bove it
+And she [E]was     [A]     [D]     [A]
+[E]Joining the [A]world of [D]missing [A]persons
+And she [E]was     [A]     [D]     [A]
+[E]Missing e[A]nough to [D]feel al[A]right
+And she [E]was
+

--- a/songs/anyone_else_but_you.cho
+++ b/songs/anyone_else_but_you.cho
@@ -1,0 +1,71 @@
+{t:Anyone Else But You}
+{st:Moldy Peaches}
+
+#
+#Hello so this is my First tab easy and simple good song good band.
+#
+#the Chords used in this song are only G and Cmaj7
+#
+#your going to play down down up up down up
+#for the intro its going to be a G chord then and Cmaj7 chord twice
+#you play the G with that picking then the Cmaj7 then G and then let the last Cmaj7 ring
+#
+# Modified as performed by Michael Cera and Ellen Page -dm
+#
+Intro: [G] [Cmaj7] [G] [Cmaj7]
+You're a [G]part time lover and a full time friend
+The [Cmaj7]monkey on you're back is the latest trend
+I [G]don't see what anyone can see, in anyone [Cmaj7]else
+But [G]you
+
+[G]Here is the church and here is the steeple
+We [Cmaj7]sure are cute for two ugly people
+I [G]don't see what anyone can see, in anyone [Cmaj7]else
+But [G]you
+
+#[G]I will find my nitch in your car
+#[Cmaj7]With my mp3 DVD rumple-packed guitar
+#I [G]don't see what anyone can see, in anyone [Cmaj7]else
+#But [G]you
+#
+#[G]Up up down down left right left right B A start
+#[Cmaj7]Just because we use cheats doesn't mean we're not smart
+#I [G]don't see what anyone can see, in anyone [Cmaj7]else
+#But [G]you
+#
+We [G]both have shiny happy fits of rage
+You [Cmaj7]want more fans, I want more stage
+I [G]don't see what anyone can see, in anyone [Cmaj7]else
+But [G]you
+
+[G]You are always trying to keep it real
+[Cmaj7]I'm in love with how you feel
+I [G]don't see what anyone can see, in anyone [Cmaj7]else
+But [G]you
+
+{colb}
+I [G]kiss you on the brain in the shadow of a train
+I [Cmaj7]kiss you all starry eyed, my body's swinging
+from side to side
+I [G]don't see what anyone can see, in anyone [Cmaj7]else
+But [G]you
+
+The [G]pebbles forgive me, the trees forgive me
+[Cmaj7]So why can't, you forgive me?
+I [G]don't see what anyone can see, in anyone [Cmaj7]else
+But [G]you
+
+#[G]Don Quixote was a steel driving man
+#[Cmaj7]My name is Adam I'm your biggest fan
+#I [G]don't see what anyone can see, in anyone [Cmaj7]else
+#But [G]you
+#
+#[G]Squinched up your face and did a dance
+#[Cmaj7]You shook a little turd out of the bottom of your pants
+#I [G]don't see what anyone can see, in anyone [Cmaj7]else
+#But [G]you
+#
+[G]dute du du dute du du dute du du duu.
+[C]dute du du dute du du dute du du duu.
+I [G]don't see what anyone can see, in anyone [Cmaj7]else
+But [G]you

--- a/songs/badfish.cho
+++ b/songs/badfish.cho
@@ -1,0 +1,48 @@
+
+{t:Badfish}
+{st:Sublime}
+
+[A] (soft voices [Bm] in background) [G]
+[A] (soft voices [Bm] in background) [G]
+
+{comment: reggae rhythm}
+
+[A]When you grab ahold of [Bm]me
+You [G]tell me that I'll never be set [A]free
+[A]But I'm a paras[Bm]ite.
+[G]Creep and crawl I step into the [A]night.
+
+[A]Two pints of [D]booze.
+Tell me [G]are you a badfish too?[A]
+(are you a badfish too?)
+[D]Ain't got no money to spend [A]
+[D]I wish the night would [A]never end.
+[D]Lord knows I'm [A]weak.
+Won't some[D]body get me off of this [E]reef?
+
+[A]Baby you're a big blue [Bm]whale.
+[G]Grab the reef when all duck divin' [A]fails.
+[A]I swim, but I wish I never [Bm]learned.
+[G]The water's too polluted with [A]germs.
+
+{colb}
+
+[A]I dive deep when it's ten feet over[D]head.
+[G]grab the reef underneath my [A]bed
+(underneath my bed)
+[D]Aint got no quarrels with [A]God.
+[D]Ain't got no time to grow [A]old.
+[D]Lord knows I'm [A]weak.
+Won't some[D]body get me off of this [E]reef?
+{comment: Whheeeeeerrrrrrrrrr! sound}
+
+[A] (slow picking) [Bm]           [G]
+
+[A] (guitar solo) [Bm]           [G]
+[A] (guitar solo) [Bm]           [G]
+
+[D]Aint got no quarrels with [A]God.
+[D]Ain't got no time to get [A]old.
+[D]Lord knows I'm [A]weak.
+Won't some[D]body get me off of this [E]reef?
+

--- a/songs/big_yellow_taxi.cho
+++ b/songs/big_yellow_taxi.cho
@@ -1,0 +1,36 @@
+
+{t:Big Yellow Taxi}
+{st:Joni Mitchell}
+
+{comment: Intro A B E}
+
+They [A]paved paradise, put up a parking [E]lot.
+[A]With a pink hotel, [B]a boutique, and a [E]swingin' hot spot.
+[E]Don't it always seem to go,
+that you [A]don't know what you've got 'til it's [E]gone.
+They [A]paved paradise, [B]put up a parking [E]lot.
+
+They [A]took all the trees, put 'em in a tree mu[E]seum.
+[A]And they charged the people a [B]dollar and a half just to [E]see 'em.
+[E]Don't it always seem to go,
+that you [A]don't know what you've got 'til it's [E]gone.
+They [A]paved paradise, [B]put up a parking [E]lot.
+
+[A]Hey farmer, farmer, put away that DD[E]T now.
+Gimme [A]spots on my apples but [B]give me the birds and the [E]bees (pleease!)
+[E]Don't it always seem to go,
+that you [A]don't know what you've got 'til it's [E]gone.
+They [A]paved paradise, [B]put up a parking [E]lot.
+
+[A]Late last night, I heard the screen door [E]slam
+And a [A]big yellow taxi [B]took away my old [E]man.
+[E]Don't it always seem to go,
+that you [A]don't know what you've got 'til it's [E]gone.
+They [A]paved paradise, [B]put up a parking [E]lot.
+
+(I said) [E]Don't it always seem to go,
+that you [A]don't know what you've got 'til it's [E]gone.
+They [A]paved paradise, [B]put up a parking [E]lot.
+They [A]paved paradise, [B]put up a parking [E]lot.
+(high)They [A]paved paradise, (low)[B]put up a parking [E]lot.
+

--- a/songs/burning_for_you.cho
+++ b/songs/burning_for_you.cho
@@ -1,0 +1,51 @@
+{t:Burnin' For You}
+{st:Blue Oyster Cult}
+
+[F] intro riff x 4
+
+[G] Ahhhhhh [Am] [F] [G]  [Em] [F] [Dm] [G] 
+
+(rhythm guitar chords during verse are shown at reggae strum beat - listen to track)
+
+[Am]Home in the valley, [Em] [Dm]home in the city, [F] [G]
+[Am]Home isn't pretty, [Em] [Dm]ain't no home for me. [F] [G]
+[Am]Home in the darkness, [Em] [Dm] home on the highway, [F] [G]
+[Am]Home isn't my way, [Em] [Dm] home I'll never be. [F] [G]
+
+[Am-G-Am] Burn [G]out [F]the day, [G]
+[Am-G-Am] Burn [G]out [F]the [G]night.
+[C]I can't see no reason to put up a [F] fight. [G]
+[C]I'm [G]living for [Am] givin the [G]devil his [Dm] due. [Em][F] [G]
+[Am-G-Am]I'm burnin', [G]I'm burnin'[F], I'm burnin' for you. [G] [Am-G-Am] [G] [F] [G]
+[Am-G-Am]I'm burnin', [G]I'm burnin'[F], I'm burnin' for you. [G] [Am-G-Am] [G] [F] [G]
+
+[F] intro riff X 2
+
+[G] Ahhhhhh (and solo) [Am] [F] [G]  [Em] [F] [Dm] [G] 
+
+[Am]Time is the asset,[Em] [Dm] time is the season. [F] [G]
+[Am]Time ain't no reason,[Em] [Dm] got no time to slow. [F] [G]
+[Am]Time everlasting,[Em] [Dm] time to play B-sides. [F] [G]
+[Am]Time ain't on my side,[Em] [Dm] time I'll never know. [F] [G]
+
+[Am-G-Am] Burn [G]out [F]the day, [G]
+[Am-G-Am] Burn [G]out [F]the [G]night.
+[C]I'm not the one to tell you what's wrong or what's [F]right. [G]
+[C]I've seen [G]suns that were [Am]freezin' and [G]lives that were [Dm] through. [Em][F] [G]
+[Am-G-Am]I'm burnin', [G]I'm burnin'[F], I'm burnin' for you. [G] [Am-G-Am] [G] [F] [G]
+[Am-G-Am]I'm burnin', [G]I'm burnin'[F], I'm burnin' for you. [G] [Am-G-Am] [G] [F] [G]
+
+
+verse chords and solo
+
+
+[Am-G-Am] Burn [G]out [F]the day, [G]
+[Am-G-Am] Burn [G]out [F]the [G]night.
+[C]I can't see no reason to put up a [F] fight. [G]
+[C]I'm [G]living for Am givin the [G]devil his [D] due. [Em][F] [G]
+[Am-G-Am]I'm burnin', [G]I'm burnin'[F], I'm burnin' for you [G] [Am-G-Am] [G] [F] [G]
+[Am-G-Am]I'm burnin', [G]I'm burnin'[F], I'm burnin' for you [G] [Am-G-Am] [G] [F] [G]
+[Am-G-Am]I'm burnin', [G]I'm burnin'[F], I'm burnin' for you [G] [Am-G-Am] [G] [F] [G]
+[Am-G-Am]I'm burnin', [G]I'm burnin'[F], I'm burnin' for you [G] [Am-G-Am] [G] [F] [G]
+
+

--- a/songs/christians_and_pagans.cho
+++ b/songs/christians_and_pagans.cho
@@ -1,0 +1,49 @@
+{even}
+{t:The Christians and the Pagans}
+{st:Dar Williams}
+#From Mortal City
+#
+#Transcription by Ron Greitzer <Rongrittz@aol.com>
+#
+#Date: January 1998
+{comment:Capo 1}
+
+Intro: [G] [C] [Am] [D] [D/F#]
+
+[G]Amber called her [C]uncle, said "We're [Am]up here for the [D]holiday,
+[G]Jane and I were [C]having solstice, [Am]now we need a [D]place to stay."
+And [Em]her Christ-loving [C]uncle watched his [Am]wife hang Mary [D]on a tree,
+He [Em]watched his son hang [C]candy canes all [Am]made with red dye [D]number three.
+He [G]told his niece, "It's [C]Christmas eve, I [Am]know our life is [D]not your style,"
+She said, [G]"Christmas is like [C]Solstice, and we [Am]miss you and it's [D]been awhile,"
+
+So the [G]Christians and the [C]Pagans sat [Em]together at the [D]table,
+[G]Finding faith and [C]common ground the [Em]best that they were [D]able, 
+And [Em]just before the [C]meal was served, [Am]hands were held and [D]prayers were said,
+[Em]Sending hope for [C]peace on earth to [Am]all their gods and [D]goddesses. [G]
+
+The [G]food was great, the [C]tree plugged in, the [Am]meal had gone with[D]out a hitch,
+Till [G]Timmy turned to [C]Amber and said, [Am]"Is it true that [D]you're a witch?"
+His [Em]mom jumped up and [C]said, "The pies are [Am]burning," and she [D]hit the kitchen,
+And [Em]it was Jane who [C]spoke, she said, "It's [Am]true, your cousin's [D]not a Christian,"
+"But [G]we love trees, we [C]love the snow, the [Am]friends we have, the [D]world we share,
+And [G]you find magic [C]from your God, and [Am]we find magic [D]everywhere."
+
+So the [G]Christians and the [C]Pagans sat [Em]together at the [D]table,
+[G]Finding faith and [C]common ground the [Em]best that they were [D]able, 
+And [Em]where does magic [C]come from, I think [Am]magic's in the [D]learning,
+Cause now when [Em]Christians sit with [C]Pagans only [Am]pumpkin pies are [D]burning.
+
+When [G]Amber tried to [C]do the dishes, her [Am]aunt said, "Really, [D]no, don't bother."
+[G]Amber's uncle saw how Amber [Am]looked like Tim and [D]like her father.
+He [Em]thought about his [C]brother, how they [Am]hadn't spoken [D]in a year,
+He [Em]thought he'd call him [C]up and say, "It's [Am]Christmas and your [D]daughter's here."
+He [G]thought of fathers, [C]sons and brothers, [Am]saw his own son [D]tug his sleeve, saying,
+[G]"Can I be a [C]Pagan?"  Dad said, [Am]"We'll discuss it [D]when they leave,"
+
+So the [G]Christians and the [C]Pagans sat [Em]together at the [D]table,
+[G]Finding faith and [C]common ground the [Em]best that they were [D]able, 
+[Em]Lighting trees in [C]darkness, learning [Am]new ways from the [D]old, and
+[Em]Making sense of [C]history and [Am]drawing warmth out [D]of the cold.
+
+[G] [C] [G]

--- a/songs/clocks.cho
+++ b/songs/clocks.cho
@@ -1,0 +1,41 @@
+
+{t:Clocks}
+{st:Coldplay}
+
+{define:Fmaj7 1 0 3 2 1 x}
+
+{comment:Capo on 1st fret}
+
+/ D - - - / Am - - - / Am - - - / Em - - - / (x2)
+
+[D]Lights go out and I [Am]can't be saved, tides that I tried to [Em]swim against
+[D]Brought me down [Am]upon my knees, oh I beg I [Em]beg and plead -singing
+[D]Come out of the [Am]things unsaid, shoot an apple [Em]off my head - and a
+[D]trouble that [Am]can't be named, tigers waiting [Em]to be tamed - singing
+[D]  yoooo[Am]oooooooh    aahh[Em]       yoo[D]ooooooo[Am]ooh    aahh [Em]
+
+/ D - - - / Am - - - / Am - - - / Em - - - / (x2)
+
+Co[D]nfusion [Am]never stops, closing walls and [Em]ticking clocks - gonna
+[D]come back and [Am]take you home, I could not stop the [Em]tune now known - singing
+[D]Come out upon [Am]my seas, curse missed oppor[Em]tunities - am I
+[D]a part o[Am]f the cure, or am I a part of [Em]the disease? - singing
+[D] you-[Am]ooooooooooh    [Em]are      [D] you-[Am]oooooooooh    [Em]aahh
+
+Bridge:
+
+[Fmaj7]  and nothing else compares [C] [G]
+[Fmaj7]  oh nothing else compares [C] [G]
+[Fmaj7]  and nothing else compares [C] [G] [F(4)]
+
+/ D - - - / Am - - - / Am - - - / Em - - - / (x2)
+
+[D] you-[Am]ooooooooooh    [Em]are      [D] you-[Am]oooooooooh    [Em]aahh
+
+# {colb}
+[D]Home, [Am]home, where I wanted to [Em]go
+[D]Home, [Am]home, where I wanted to [Em]go
+[D]Home, [Am]home, where I wanted to [Em]go
+[D]Home, [Am]home, where I wanted to [Em]go
+
+{comment:End on D}

--- a/songs/comfortably_numb.cho
+++ b/songs/comfortably_numb.cho
@@ -1,0 +1,72 @@
+
+{even}
+{t:Comfortably Numb}
+{st:Pink Floyd}
+
+{comment:Capo 1}
+
+{sot}
+Main strum:             D       D   D U D U D   D   D U   
+                        1 + 2 + 3 + 4 + 1 + 2 + 3 + 4 +
+G to Em Walkdown Strum: B       D   B   B       D   D U
+                        G           F#  Em
+{eot}
+
+{define: Dm x x 0 2 3 1}
+{define: Bb x 1 3 3 3 x}
+
+Intro:  Am x4
+
+[Am(2)]Hello.  Is there anybody [G(2)]in there?
+Just [F]nod if you can hear me.     [Dm]  Is there [Am(2)]anyone home?
+[Am(2)]Come on, now.  I hear you're [G(2)]feeling down.
+Well, [F]I can ease your pain[Dm],  get you [Am(2)]on your feet again.
+[Am(2)]Relax.   I need some infor[G(2)]mation first.
+[F]Just the basic facts:[Dm]  Can you [Am(2)]show me where it hurts?
+
+Chorus 1:
+[C(2)]  There is no pain, you are re[G(2)]ceding.
+[C(2)]   A distant ships smoke on the ho[G(2)]rizon.
+[Bb(2)]   You are only coming through in wav[F(2)]es.
+Your [Bb(2)]lips move, but I can't hear what you're saying.[F(2)]
+When [C(2)]I was a child I had a fe[G(2)]ver.
+My [C(2)]hands felt just like two bal[G(2)]loons.
+[Bb(2)]   Now I've got that feeling once again.  [F(2)]I can't explain, you would not
+[Bb(2)]understand.  This is not how I am.[F(2)]
+[G(2)]I           [Bb]  have become[F] comfortably numb.[C(2)]
+
+# {colb}
+SOLO 1:
+{sot}
+/ C - - - / - - - - / G - - - / - - - - /
+/ C - - - / - - - - / G - - - / - - - - /
+/ Bb - - - / - - - - / F - - - / - - - - /
+/ Bb - - - / - - - - / F - - - / - - - - /
+{eot}
+
+[G(2)]I           [Bb]  have become[F] comfortably numb.[C(2)]
+
+[Am(2)]Okay,  just a little pin[G(2)]prick.
+There'll be no more "Aaa[F]aaah!".[Dm]  But you may feel a [Am(2)]little sick.
+Can you sta[Am(2)]nd up?  I do believe it's work[G(2)]ing good.
+That'll keep you go[F]ing for the show.[Dm]  Come on, [Am(2)]it's time to go.
+
+Chorus 2:
+[C(2)]   There is no pain, you are re[G(2)]ceding.
+[C(2)]   A distant ships smoke on the horizon.[G(2)]
+[Bb(2)]   You are only coming through in waves.[F(2)]
+Your [Bb(2)]lips move, but I can't hear what you're saying.[F(2)]
+When [C(2)]I was a child, I caught a flee[G(2)]ting glimpse,
+[C(2)]    Out of the corner of my eye.[G(2)]
+[Bb(2)]    I turned to look, but it was gone. [F(2)] I cannot put my finger
+[Bb(2)]on it now.  The child is grown, the dream [F(2)]is gone.
+[G(2)]I           [Bb]  have become[F] comfortably numb.[C(4)]
+
+Solo 2 (repeat progression 8x):
+
+{sot}
+/Am - - - / - - - - / G - - - / - - - - /
+/F - - - / Dm - - - / Am - - - / - - - - /
+{eot}
+
+{comment:End on Am}

--- a/songs/coming_up_close.cho
+++ b/songs/coming_up_close.cho
@@ -1,0 +1,93 @@
+{t:Coming Up Close}
+{st:Til Tuesday}
+
+{comment:Capo first fret}
+
+[G]
+(mini solo)
+#{sot}
+#|-3-------------------------------|-------|
+#|-0-------------------------------|-------|
+#|-0-------------------------------|-------|
+#|-0------------5-----5h75---------|-------|
+#|-2----0-2-3-3---5-3------5-3-2-0-|-------|
+#|-3--3----------------------------|-3-----|
+#{eot}
+
+[G]One night in Iowa,
+he and I in a borrowed car.
+[Em]Went driving in the summer,
+promises in every star.
+[C]Out in the distance, I could
+hear some people laughing.
+[Am]I felt my heart beat back
+a weekend's worth of sadness.
+
+[G]
+(mini solo)
+#{sot}
+#|---------------------------------|-------|
+#|---------------------------------|-------|
+#|---------------------------------|-------|
+#|-------------5h75----------------|-------|
+#|-----0-2-3-3------5--------------|-------|
+#|-3-3----------------5h75-3-------|-3-----|
+#{eot}
+
+[G]There was a farmhouse
+that had long since been deserted.
+[Em]We stopped and carved our hearts
+into the wooden surface.
+[C]We thought just for an instant
+we could see the future.
+[Am]We thought for once we knew
+what really was important.
+
+Chorus part 1:
+[G]Coming up [C]close. Everything sounds like
+'Welcome [G]Home'. Come [C]home.
+{colb}
+Chorus part 2:
+And oh, by the [G]way -
+[Em]Don't you know that I could make
+a [Am]dream that's barely half-awake
+come [C]true.
+I [C]wanted to [G]say -
+but [Em]anything I could have said
+I [Am]felt somehow that you already
+[C]knew.
+
+[G] [E] [C] [Am]
+(solo)
+#{sot}
+#|--------------------------------|------------------|
+#|--------------------------------|------------------|
+#|--------------------------------|------------------|
+#|------------------5-------------|---------5--------|
+#|-----5------0-2-3---5-3-2-------|---0-2-3---5-3----|
+#|-3------3--3--------------------|-3----------------|
+#
+#|--------------------------------|------------------|
+#|--------------------------------|------------------|
+#|---------4----------------------|------------------|
+#|-----------5-----5---5h75-------|-5h75-------------|
+#|---0-2-3-----5-3---5------5-----|------5-3-2-0-----|
+#|-3------------------------------|---------------3--|
+#{eot}
+
+[G]We got back in the car
+and listened to a Dylan tape.
+[Em]We drove around the fields
+until it started getting late,
+[C]and I went back to my hotel room
+on the highway,
+[Am]and he just got back in his car
+and drove away.
+
+(chorus part 1 and 2)
+
+(chorus part 1)
+(chorus part 1)
+
+[G]Come on home.
+

--- a/songs/crazy_on_you.cho
+++ b/songs/crazy_on_you.cho
@@ -1,0 +1,130 @@
+#From: "Stephen D. Burd" 
+#Date: Fri, 1 May 1998 11:11:20 -0700
+#Subject: h/heart/crazy_on_you.crd
+#
+{t:Crazy On You}
+{st:Dreamboat Annie (Heart)}
+
+Intro: (double-strummed)
+[Am]     [F]     [Am]      [F]
+(add Lead #1)
+[Am]     [F]     [Am]      [F]
+[Am]     [G]     [F]
+
+Lead #1:
+{sot}
+e------------------------------------------------------------|
+b------------------------------------------------------------|
+g------------------------------------------------------------|
+d-----2-0-------------------------2-0------------------------|
+a-0-------3-2-0-----------------0-----3-2-0------------------|
+E---------------1-----------3---------------1-----------3----|
+
+e------------------------------------------------------------|
+b------------------------------------------------------------|
+g------------------------------------------------------------|
+d-----2-0-----------2-0-----------2-0------------------------|
+a-0-------3-2-0---------3-2-0---------3-2---0----------------|
+E---------------3-------------1-----------3------------------|
+{eot}
+We may [Am]still have time, we might [C]still get by
+Every [Dm7]time I think about it [E7]I want to cry
+With [Am]bombs and the devils and the [C]kids keep coming
+No[Dm7]where to breathe easy no [E7]time to be young[Am]   [Am]   [D]   [Am]   [Am]   [D]
+But I [F]tell my[G]self that I'm [C]doing all [F]right
+There's [Dm7]nothing left to do to[E7]night
+
+(add Lead #1 to Chorus)
+But go [Am]crazy on [F]you
+[Am]Crazy on [F]you
+Let me go [Am]crazy crazy on [G]you        [F]
+
+My [Am]love is the evening breeze [C]touching your skin
+The [Dm7]gentle sweet singing of [E7]leaves in the wind
+The [Am]whisper that calls after [C]you in the night
+And [Dm7]kisses your ear in the [E7]early light    [Am]   [Am]   [D]    [Am]   [Am]   [D]
+And [F]you don't need to [G]wonder you're [C]doing [F]fine
+[Dm7]And my love the pleasure's [E7]mine
+
+(add Lead #1 to Chorus)
+Let me go [Am]crazy on [F]you
+[Am]Crazy on [F]you
+Let me go [Am]crazy crazy on [G]you        [F]          [Am]
+
+{colb}
+[F#m7]Wild man's world is [Bm7]crying in pain
+[C#m7]What're you going to do - ever[D]body's insane
+[C#m7]So afraid of one who's so [D]afraid of you
+What're you [C#m7]going to do? [D]
+[A]
+[E]     [E/F#]       [E/G#]       [E/A]
+
+(add Lead #1 to Chorus)
+[Am]Crazy on [F]you
+[Am]Crazy on [F]you
+Let me go [Am]crazy crazy on [G]you        [F]
+
+[Am]I was a willow last [C]night in my dream
+I [Dm7]bent down over a [E7]clear running stream
+I [Am]sang you a song that I he[C]ard up above
+And you [Dm7]kept me alive with your [E7]sweet flowing love
+
+(add Lead #1 to Chorus)
+[Am]Crazy on [F]you
+[Am]Crazy on [F]you
+Let me go [Am]crazy crazy on [G]you        [F]          [Am]
+
+[Am]Crazy on [F]you
+[Am]Crazy on [F]you
+Let me go [Am]crazy crazy on [G]you        [F]          [Am]
+
+(Add Lead #2 over next two lines of chords)
+[Am]      [F]      [Am]      [F]
+[Am]      [G]      [F]      [Am]
+(Add Lead #3 over next two lines of chords)
+[F#m7]      [Bm7]      [C#m7]      [D]
+[C#m7]      [D]      [C#m7]      [D]
+[A]
+[E]     [E/F#]       [E/G#]       [E/A]
+(add Lead #1 to Chorus)
+[Am]Crazy on [F]you
+[Am]Crazy on [F]you
+Let me go [Am]crazy crazy on [G]you        [F]
+
+#
+#Lead #2
+#
+#Sorry, I haven't worked this one out yet!
+#
+#
+#Lead #3
+#
+#{sot}
+#e------------------------------------------------------------|
+#b------------------------------------------------------------|
+#g---------------------------------------------4--------------|
+#d-------------2---------------------------4-6---7------------|
+#a---------2-4---5-----------------4---5-7--------------------|
+#E-2---4-5----------------------------------------------------|
+#
+#e---------------------------------------------7--------------|
+#b-----------------------------------------7-9---10-----------|
+#g---------6-7-9-7-----------------6---7-9--------------------|
+#d-6---7-9----------------------------------------------------|
+#a------------------------------------------------------------|
+#E------------------------------------------------------------|
+#
+#e-------10----------------10---------------------------------|
+#b-10/12----12\10----10/12----12\10---------------------------|
+#g------------------------------------------------------------|
+#d------------------------------------------------------------|
+#a------------------------------------------------------------|
+#E------------------------------------------------------------|
+#{eot}
+#
+{define: Dm7  x x 0 2 1 1}
+{define: E7   x 2 0 1 3 0}
+{define: F#7  2 4 2 2 2 2}
+{define: Bm7  x 2 4 2 3 2}
+# {define: C#m7 x 4 6 4 5 4}
+

--- a/songs/crazy_on_you_2.cho
+++ b/songs/crazy_on_you_2.cho
@@ -1,0 +1,134 @@
+#From: "Stephen D. Burd" 
+#Date: Fri, 1 May 1998 11:11:20 -0700
+#Subject: h/heart/crazy_on_you.crd
+#
+{t:Crazy On You}
+{st:Dreamboat Annie (Heart)}
+
+(Acoustic intro)
+
+Intro: (double-strummed)
+[Am]     [F]     [Am]      [F]
+(add Lead #1)
+[Am]     [F]     [Am]      [F]
+[Am]     [G]     [F]
+
+Lead #1:
+{sot}
+e------------------------------------------------------------|
+b------------------------------------------------------------|
+g------------------------------------------------------------|
+d-----2-0-------------------------2-0------------------------|
+a-0-------3-2-0-----------------0-----3-2-0------------------|
+E---------------1-----------3---------------1-----------3----|
+
+e------------------------------------------------------------|
+b------------------------------------------------------------|
+g------------------------------------------------------------|
+d-----2-0-----------2-0-----------2-0------------------------|
+a-0-------3-2-0---------3-2-0---------3-2---0----------------|
+E---------------3-------------1-----------3------------------|
+{eot}
+
+We may [Am]still have time, we might [C]still get by.
+Every [Dm7]time I think about it [E7]I want to cry.
+With [Am]bombs and the devils and the [C]kids keep coming,
+No[Dm7]where to breathe easy no [E7]time to be young[Am]   [Am]   [D7]   [Am]   [Am]   [D7]
+But I [Dm7]tell my[Em]self that I'm [C]doing all [F]right
+There's [Dm7]nothing left to do to[E7]night,
+
+(add Lead #1 to Chorus)
+But go [Am]crazy on [F]you
+[Am]Crazy on [F]you
+Let me go [Am]crazy crazy on [G]you        [F]
+
+My [Am]love is the evening breeze [C]touching your skin
+The [Dm7]gentle sweet singing of [E7]leaves in the wind
+The [Am]whisper that calls after [C]you in the night
+And [Dm7]kisses your ear in the [E7]early light    [Am]   [Am]   [D7]    [Am]   [Am]   [D7]
+And [Dm7]you don't need to [Em]wonder you're [C]doing [F]fine,
+[Dm7]And my love the pleasure's [E7]mine
+
+(add Lead #1 to Chorus)
+Let me go [Am]crazy on [F]you
+[Am]Crazy on [F]you
+Let me go [Am]crazy crazy on [G]you        [F]          [Am]
+
+{colb}
+[F#m7]Wild man's world is [D]crying in pain
+[C#m7]What're you going to do - ever[D]body's insane
+[C#m7]So afraid of one who's so [D]afraid of you
+What're you [C#m7]going to do? [Bm7]
+[A]
+[E]     [E/F#]       [E/G#]   [A]    [E/B]
+
+(add Lead #1 to Chorus)
+[Am]Crazy on [F]you
+[Am]Crazy on [F]you
+Let me go [Am]crazy crazy on [G]you        [F]
+
+[Am]I was a willow last [C]night in my dream,
+I [Dm7]bent down over a [E7]clear running stream
+I [Am]sang you a song that I he[C]ard up above,
+And you [Dm7]kept me alive with your [E7]sweet flowing love
+
+(add Lead #1 to Chorus)
+[Am]Crazy (on [F]you)
+[Am]Crazy on [F]you
+Let me go [Am]crazy crazy on [G]you        [F]          [Am]
+
+[Am]Crazy on [F]you
+[Am]Crazy on [F]you
+Let me go [Am]crazy crazy on [G]you        [F]          [Am]
+
+(Add Lead #2 over next two lines of chords)
+[Am]      [F]      [Am]      [F]
+[Am]      [G]      [F]      [Am]
+(Add Lead #3 over next two lines of chords)
+[F#m7]      [D]      [C#m7]      [D]
+[C#m7]      [D]      [C#m7]      [Bm7]
+[A]
+[E]     [E/F#]       [E/G#]   [A]    [E/B]
+(add Lead #1 to Chorus)
+[Am]Crazy on [F]you
+[Am]Crazy on [F]you
+Let me go [Am]crazy crazy on [G]you        [F]
+
+#
+#Lead #2
+#
+#Sorry, I haven't worked this one out yet!
+#
+#
+#Lead #3
+#
+#{sot}
+#e------------------------------------------------------------|
+#b------------------------------------------------------------|
+#g---------------------------------------------4--------------|
+#d-------------2---------------------------4-6---7------------|
+#a---------2-4---5-----------------4---5-7--------------------|
+#E-2---4-5----------------------------------------------------|
+#
+#e---------------------------------------------7--------------|
+#b-----------------------------------------7-9---10-----------|
+#g---------6-7-9-7-----------------6---7-9--------------------|
+#d-6---7-9----------------------------------------------------|
+#a------------------------------------------------------------|
+#E------------------------------------------------------------|
+#
+#e-------10----------------10---------------------------------|
+#b-10/12----12\10----10/12----12\10---------------------------|
+#g------------------------------------------------------------|
+#d------------------------------------------------------------|
+#a------------------------------------------------------------|
+#E------------------------------------------------------------|
+#{eot}
+#
+{define: F#m7 2 4 2 2 2 2}
+{define: Dm7  x x 0 2 1 1}
+{define: E7   x 2 0 1 3 0}
+{define: F#7  2 4 2 2 2 2}
+{define: Bm7  x 2 4 2 3 2}
+{define: C#m7 x 4 6 4 5 4}
+

--- a/songs/crazy_on_you_3.cho
+++ b/songs/crazy_on_you_3.cho
@@ -1,0 +1,76 @@
+{t:Crazy On You}
+{st:Dreamboat Annie (Heart)}
+
+(Acoustic intro)
+
+Intro: (double-strummed)
+[Am]     [F]     [Am]      [F]
+
+Instrumental Chorus: (Add bass riff)
+[Am]     [F]     [Am]      [F]
+[Am]     [G]     [F]
+
+We may [Am]still have time, we might [C/G]still get by.
+Every [Dm]time I think about it [E]I want to cry.
+With [Am]bombs and the devils and little [C/G]kids keep comin',
+no[Dm]where to breathe easy, no [E]time to be young. [Am]   [Am]   [Dsus2]   [Am]   [Am]   [Dsus2]
+But I [Dm]tell my[Em]self that I'm [C]doin' all [F]right;
+there's [Dm]nothing left to do to[E]night, but go
+
+Chorus:
+[Am]crazy on [F]you,
+[Am]crazy on [F]you.
+Let me go [Am]crazy, crazy on [G]you, oh oh [F]
+
+My [Am]love is the evening breeze [C/G]touching your skin,
+the [Dm]gentle sweet singing of [E]leaves in the wind.
+The [Am]whisper that calls after [C/G]you in the night,
+and [Dm]kisses your ear in the [E]early light.    [Am]   [Am]   [Dsus2]    [Am]   [Am]   [Dsus2]
+And [Dm]you don't need to [Em]wonder you're [C]doing [F]fine,
+[Dm]my love the pleasure's [E]mine, let me go
+
+[Am]crazy on [F]you
+[Am]Crazy on [F]you
+Let me go [Am]crazy crazy on [G]you        [F]          [Am]
+
+{colb}
+[F#m]While the man's world is [D]cryin' in shame
+[C#m]What're you going to do when every[D]body's insane?
+[C#m]So afraid of wonder, so [D]afraid of you,
+What-cha [C#m]gonna do -o[Bm]o- -oo-? [Bm]
+[A]Oh...    [A]
+[E]Ahhh... [E]Ah-ahhh...      [Esus]Ahh....           [Esus]
+
+[Am]Crazy on [F]you
+[Am]Crazy on [F]you
+Let me go [Am]crazy crazy on [G]you        [F]
+
+[Am]I was a willow last [C/G]night in my dream,
+I [Dm]bent down over a [E]clear running stream
+I [Am]sang you a song that I he[C]ard up above,
+and you [Dm]kept me alive with your [E]sweet flowing love.
+
+[Am]Crazy (on [F]you)
+[Am]Crazy on [F]you
+Let me go [Am]crazy crazy on [G]you        [F]          [Am]
+
+[Am]Crazy on [F]you
+[Am]Crazy on [F]you
+Let me go [Am]crazy crazy on [G]you        [F]          [Am]
+
+(Add bass riff + solo)
+[Am]      [F]      [Am]      [F]
+[Am]      [G]      [F]      [Am]
+
+(Instrumental)
+[F#m]      [D]      [C#m]      [D]
+[C#m]      [D]      [C#m]      [Bm]
+[A] [A]
+[E]     [E]       [Esus]   [Esus]
+
+[Am]Crazy on [F]you
+[Am]Crazy on [F]you
+Let me go [Am]crazy crazy on [G]you        [F]
+
+...[Am]Oh!
+

--- a/songs/cruel_to_be_kind.cho
+++ b/songs/cruel_to_be_kind.cho
@@ -1,0 +1,92 @@
+
+{title:Cruel to be Kind}
+{st:Nick Lowe}
+
+[C] (intro) [G]     [F]      [G]
+[C]         [G]     [F]      [G]
+[G]
+
+Oh,
+[C]I can't take another [Em]heartache
+Though you [F]say you're my friend,
+[G]I'm at my wit's end
+[C]You say your love is [Em]bonafide,
+But that [F]don't coin[Am]cide
+[Dm]   With the things that you [F]do and
+when I [Em]ask you to be [F]nice
+You [G]say you've got to be...
+
+[F]Cruel to be [G]kind [Em]in the right [Am]measure
+[F]Cruel to be [G]kind it's a [Em]very good [Am]sign
+[F]Cruel to be [G]kind [Em]means that I [Am]love you
+[G]Baby, got to be cruel (got to be cruel) to be kind
+
+[C]         [Em]     [F]      [G]
+
+Well [C]I do my best to under[Em]stand dear
+But you [F]still mystify and [G]I want to know why
+[C]I pick myself up[Em]off the ground
+To have you [F]knock me [Am]back down
+[Dm]    Again and [F]again and when I [Em]ask you to ex[F]plain, you
+[G]say, you've got to be...
+
+[F]Cruel to be [G]kind [Em]in the right [Am]measure
+[F]Cruel to be [G]kind it's a [Em]very good [Am]sign
+[F]Cruel to be [G]kind [Em]means that I [Am]love you
+[G]Baby, got to be cruel (got to be cruel) to be kind
+
+{colb}
+
+[C]Ooh ooh ooh, [A]ooh.. ooh... ooh...
+
+[F]Cruel to be [G]kind [Em]in the right [Am]measure
+[F]Cruel to be [G]kind it's a [Em]very good [Am]sign
+[F]Cruel to be [G]kind [Em]means that I [Am]love you
+[G]Baby, got to be cruel (got to be cruel) to be kind
+
+{comment: Solo over verse chords}
+
+[F]    [G]    [Em]    [Am]
+[F]    [G]    [Em]    [Am]
+[F]    [G]    [Em]    [Am]
+[G]
+
+#
+#{sot}
+#    |     |     |     |        |     |     |     |      
+#A|--0-----0--0--2--2--------|--2--0--2-----3-----3-----|
+#E|--1-----1--1--3--3--------|--3--3--3-----5-----5-----|
+#C|--0-----0--0--2--2--------|--4--4--4-----4-----4-----|   (x3)
+#G|--2-----2--2--0--0--------|--0--0--0-----------------|
+#
+#    |     |     |     |        |     |     |     |      
+#A|-------------/8-----------|--7-----------5-----------|
+#E|--------------------------|-----8-----------7--------|
+#C|--------------------------|--------7-----------7-----|
+#G|--------------------------|--------------------------|
+#
+#    |     |     |     |      
+#A|--3-----2-----0---------2-|
+#E|----5----3------1-----1---|
+#C|------5----4------2-------|
+#G|--------------------0-----|
+#{eot}
+
+Well I
+[C]do my best to under[Em]stand dear But you
+[F]still mystify and [G]I want to know why
+[C]I pick myself up[Em]off the ground to have you
+[F]knock me [Am]back down
+[Dm]     Again and [F]again and when I [Em]ask you to ex[F]plain You
+[G]say, you've got to be...
+
+[F]Cruel to be [G]kind [Em]in the right [Am]measure
+[F]Cruel to be [G]kind it's a [Em]very good [Am]sign
+[F]Cruel to be [G]kind [Em]means that I [Am]love you
+[G]Baby, got to be cruel (got to be cruel) to be kind
+
+[F]Cruel to be [G]kind [Em]in the right [Am]measure
+[F]Cruel to be [G]kind it's a [Em]very, very, very good [Am]sign,
+[F]Cruel to be [G]kind [Em]means that I [Am]love you, baby
+[G]Baby, got to be cruel (got to be cruel) to be kind
+

--- a/songs/dead_flowers.cho
+++ b/songs/dead_flowers.cho
@@ -1,0 +1,44 @@
+{t:Dead Flowers}
+{st:Rolling Stones}
+
+[D] [A] [G] [D]
+
+[D]Well when you're sitting [A]there
+in your [G]silk upholstered [D]chair
+[D]Talking to some [A]rich folk that you [G]know [D]
+[D]Well I hope you won't see [A]me
+in my [G]ragged compa[D]ny
+[D]Cause you know I could [A]never be a[G]lone [D]
+
+Take me [A]down little Susie, take me [D]down
+I [A]know you think you're the queen of the under[D]ground
+And you can
+[G]send me dead flowers every [D]morning
+[G]Send me dead flowers by the [D]mail
+[G]Send me dead flowers to my [D]wedding
+And I [D]won't forget to put [A]roses on your [G]grave [D]
+
+[D]Well when you're sitting [A]back
+in your [G]rose pink cadil[D]lac
+[D]Making bets on [A]Kentucky Derby [G]Day [D]
+[D]Ah, I'll be in my basement [A]room
+with a [G]needle and a [D]spoon
+[D]And another girl to [A]take my pain a[G]way [D]
+
+{colb}
+Take me [A]down little Susie, take me [D]down
+[A]I know you think you're the queen of the under[D]ground
+And you can
+[G]send me dead flowers every [D]morning
+[G]Send me dead flowers by the [D]mail
+[G]Send me dead flowers to my [D]wedding
+And I [D]won't forget to put [A]roses on your [G]grave [D]
+
+Take me [A]down little Susie, take me [D]down
+[A]I know you think you're the queen of the under[D]ground
+And you can
+[G]send me dead flowers every [D]morning
+[G]Send me dead flowers by the U S [D]mail
+[G]Say it with dead flowers at my [D]wedding
+And I [D]won't forget to put [A]roses on your [G]grave [D]
+No, I [D]won't forget to put [A]roses on your [G]grave [D]

--- a/songs/donald_wheres_your_trousers.cho
+++ b/songs/donald_wheres_your_trousers.cho
@@ -1,0 +1,58 @@
+{t:Donald Where's Your Troosers}
+{st:Andy Stewart}
+
+[Em]I just down from the Isle of Skye 
+I'm [D]no very big but I'm awful shy  
+[Em]All the lassies shout as I go by,  
+[D]"Donald, Where's Your Troo[Em]sers?"  
+
+Chorus 
+[Em]Let the wind blow high and the wind blow low  
+[D]Through the streets in my kilt I'll go  
+[Em]All the lassies say, "Hello!  
+[D]Donald, where's your troosers?" [Em]  
+[Em]A Lady took me to a ball  
+[D]And it was slippery in the hall  
+[Em]I was afeared that I wid fall  
+[D]'Cause I had nay on ma troosers  [Em]
+ 
+Chorus 
+[Em]Let the wind blow high and the wind blow low  
+[D]Through the streets in my kilt I'll go  
+All [Em]the lassies say, "Hello!  
+[D]Donald, where's your troosers?" [Em]
+
+[Em]I went down to London town  
+[D]To have a little fun in the underground  
+[Em]All the Ladies turned their heads around, saying,  
+[D]"Donald, where's your troosers?" [Em]
+
+{colb}
+Chorus 
+[Em]Let the wind blow high and the wind blow low  
+[D]Through the streets in my kilt I'll go  
+[Em]All the lassies say, "Hello!  
+[D]Donald, where's your troosers?" [Em]
+ 
+[Em]To wear the kilt is my delight, 
+[D]It is not wrong, I know it's right.  
+The [Em]highlanders would get afright  
+If [D]they saw me in my troosers. [Em]
+ 
+Chorus 
+[Em]Let the wind blow high and the wind blow low  
+[D]Through the streets in my kilt I'll go  
+[Em]All the lassies say, "Hello!  
+[D]Donald, where's your [Em]troosers?" 
+ 
+[Em]The lassies love me every one  
+[D]Just let them catch me if they can  
+[Em]You canna put the breeks on a highland man, saying, 
+'Cause he does nae wear his troosers?" 
+ 
+Chorus 
+[Em]Let the wind blow high and the wind blow low  
+[D]Through the streets in my kilt I'll go  
+[Em]All the lassies say, "Hello!  
+[D]Donald, where's your [Em]troosers?"
+

--- a/songs/down_by_the_river.cho
+++ b/songs/down_by_the_river.cho
@@ -1,0 +1,41 @@
+{t:Down By The River}
+{st:Neil Young}
+
+#
+#TITLE: DOWN BY THE RIVER
+#ALBUM: EVERYBODY KNOWS THIS IS NOWHERE
+#
+#
+#SUBMITTED BY: Malc Brookes
+#(via HyperRust)
+#
+#INTRO:
+[Em7] [A] [Em7] [A]
+
+Verse 1:
+[Em7] Be on my side, I'll [A]be on your side, baby
+[Em7] There is no reason for [A]you to hide
+[Em7] It's so hard for me [A]staying here all alone
+[Em7] When you could be taking [A]me for a ride.
+[C] Yeah [Bm] yeah,
+
+Chorus:
+[C] She could drag me [Bm]over the rainbow,
+and [C] send me away[Bm] [D]
+[G]  Down [D]by the ri[A]ver
+[G]  I [D]shot my ba[A]by
+[G]  Down [D]by the ri[A]ver
+[Em7]Dead,  [A]  oh, [Em7]  shot her [A]dead.
+
+Verse 2:
+[Em7] You take my hand, I'll [A]take your hand
+[Em7] Together we may [A]get away
+[Em7] This much madness [A]is too much sorrow
+[Em7] It's impossible to [A]make it today.
+
+(chorus)
+
+(first verse)
+
+(chorus)
+

--- a/songs/down_under.cho
+++ b/songs/down_under.cho
@@ -1,0 +1,61 @@
+{title:Down Under}
+{subtitle:Men At Work}
+
+[Bm] [A] [Bm] [G] [A]
+[Bm] [A] [Bm] [G] [A]
+
+[Bm]Traveling in a [A]fried out [Bm]kombie [G] [A]
+[Bm]On a hippie [A]trail, head full of [Bm]zombie. [G] [A]
+[Bm]I met a strange [A]lady, [Bm] she made me [G]nervous. [A]
+[Bm]She took me in [A]in and gave me [Bm]breakfast. [G] [A]
+
+{comment:Chorus 1:}
+
+{soc}
+[D]Do you come from a [A]land down un[Bm]der [G] [A]
+[D]where women [A]glow and men [Bm]plunder? [G] [A]
+[D]Can't ya hear, can't ya [A]hear the thun[Bm]der [G] [A]
+You [D]better run, you [A]better take co[Bm]ver. [G] [A]
+{eoc}
+
+{comment:flute solo during these two lines:}
+
+[Bm] [A] [Bm] [G] [A]
+[Bm] [A] [Bm] [G] [A]
+
+[Bm]Buying bread from a [A]man in Brus[Bm]sels [G] [A]
+He was [Bm]six-foot-[A]four, and full of [Bm]muscles. [G] [A]
+[Bm]I said, "do you [A]speak my lan[Bm]guage?" [G] [A]
+[Bm]He just smiled and [A]gave me a vegemite [Bm] sandwich. [G] [A]
+
+
+{comment:Chorus 2:}
+
+{soc}
+And he said, Oh,
+[D]Do you come from a [A]land down un[Bm]der [G] [A]
+[D]where beer does [A]flow and men [Bm]chunder? [G] [A]
+[D]Can't ya hear, can't ya [A]hear the thun[Bm]der? [G] [A]
+You [D]better run, you [A]better take co[Bm]ver. [G] [A]
+{eoc}
+
+{colb}
+
+[Bm] [A] [Bm] [G] [A]
+[Bm] [A] [Bm] [G] [A]
+
+[Bm]Lying in a [A]den in Bom[Bm]bay, [G] [A]
+[Bm]with a slack [A]jaw and not much [Bm]to say. [G] [A]
+[Bm]I said to the [A]man "Are you trying to [Bm]tempt me? [G] [A]
+[Bm]Because I [A]come from the land of [Bm]plenty." [G] [A]
+
+And he said, Oh,
+
+{comment:Chorus 1}
+
+{comment:Repeat Chorus 1}
+
+{comment:Repeat Chorus 1}
+
+{comment:Repeat Chorus 1, fade out}
+

--- a/songs/eight_days_a_week.cho
+++ b/songs/eight_days_a_week.cho
@@ -1,0 +1,64 @@
+
+{t:Eight Days a Week}
+{st:the Beatles}
+
+{comment: Album track is Capo 2nd fret}
+
+{comment: Intro: C D F C}
+
+[C]Oo, I need your [D7]love, babe.
+[F]Guess you know it's [C]true.
+[C]Hope you need my [D7]love, babe.
+[F]Just like I need [C]you.
+
+[Am]Hold me, [F]love me
+[Am]Hold me, [D7]love me
+[C]I ain't got nothin' but [D7]love, babe
+[F]Eight days a [C]week
+
+[C]Love you every [D7]day, girl.
+[F]Always on my [C]mind.
+[C]One thing I can [D7]say, girl,
+[F]love you all the [C]time.
+
+[Am]Hold me, [F]love me
+[Am]Hold me, [D7]love me
+[C]I ain't got nothin' but [D7]love, girl
+[F]Eight days a [C]week
+
+[G]Eight days a week
+[Am]I love you
+[D7]Eight days a week is
+[F]not enough to [G7]show I care!
+
+{colb}
+
+[C]Oo, I need your [D7]love, babe.
+[F]Yes you know it's [C]true.
+[C]Hope you need my [D7]love, babe.
+[F]Just like I need [C]you.
+
+Oh, [Am]Hold me, [F]love me
+[Am]Hold me, [D7]love me
+[C]I ain't got nothin' but [D7]love, babe
+[F]Eight days a [C]week!
+
+[G]Eight days a week
+[Am]I love you
+[D7]Eight days a week is
+[F]not enough to [G7]show I care!
+
+[C]Love you every [D7]day, girl.
+[F]Always on my [C]mind.
+[C]One thing I can [D7]say, girl,
+[F]love you all the [C]time.
+
+[Am]Hold me, [F]love me
+[Am]Hold me, [D7]love me
+[C]I ain't got nothin' but [D7]love, babe
+[F]Eight days a [C]week!
+[F]Eight days a [C]week!
+[F]Eight days a [C]week!
+
+{comment: Outro: (like intro) C D F C, let last C ring}
+

--- a/songs/flagpole_sitta.cho
+++ b/songs/flagpole_sitta.cho
@@ -1,0 +1,76 @@
+{t:Flagpole sitta}
+{st:Harvy Danger}
+
+[D] [Am] [C] [D]
+#----------------------------------------------------------------------|
+#----------------------------------------------------------------------|
+#7----9----11----14----12----11----9----7----5----9----5----9----7-----|
+#----------------------------------------------------------------------|
+#5----7----9-----12----10-----9----7----5----3----7----3----7----5-----|
+#----------------------------------------------------------------------|
+
+[D]I had visions I was in them
+I was looking into the [Am]mirror
+To see a little bit [C]clearer,
+the rottenness and evil in [D]me
+My [D]fingertips have memories
+I can't forget the curves of your [Am]body
+And when I feel a bit [C]naughty,
+I run it up the flagpole and [D]see
+who salutes, but no one ever does.
+
+[D]I'm not sick but I'm not [Am]well,
+and I'm so [C]hot, cause I'm in [D]hell
+
+[D]Been around the world and found
+that only stupid people are [Am]breeding
+The cretins cloning and [C]feeding,
+and I don't even own a [D]TV
+[D]Put me in the hospital for nerves
+and then they had to [Am]commit me
+You told them all I was [C]crazy,
+they cut off my legs now
+[D]I'm an amputee god damn you
+
+[D]I'm not sick but I'm not [Am]well,
+and I'm so [C]hot, cause I'm in [D]hell
+{colb}
+[D]I'm not sick but I'm not [Am]well,
+and it's a [C]sin, to live so [D]well
+
+[A]I wanna publish [G]'zines,
+and rage against ma[F]chines
+I wanna [G]pierce my tongue,
+it doesn't hurt, it feels[A] fine
+The trivial sub[G]lime,
+I'd like to turn off [F]time
+and kill my [A]mind...
+you kill my [D]mind... mind...
+
+[D]Paranoia, paranoia,
+everybody's comin' to [Am]get me
+Just say you never [C]met me,
+I'm running underground with the [D]moles 
+digging holes
+
+[D]Hear the voices in my head -
+I swear to god it sounds like they're [Am]snoring
+But if you're bored then you're [C]boring,
+the agony and the [D]irony they're killing me...well
+
+[D]I'm not sick but I'm not [Am]well,
+and I'm so [C]hot, cause I'm in [D]hell
+[D]I'm not sick but I'm not [Am]well,
+and it's a [C]sin, to live so [D]well
+[D] [C-slide-D] [C-slide-D] [C-slide-D] [C-slide-D]
+#
+#OUTRO
+#-------------------------------------------------|
+#-------------------------------------------------|
+#7b----7b----7b----7b----7b----7b----7b----x--/5--|
+#-------------------------------------------------|  x4
+#5b----5b----5b----5b----5b----5b----5b----x--/3--|
+#-------------------------------------------------|
+#
+#Questions? Comments?
+#pmikeytide@yahoo.com

--- a/songs/folsom_prison_blues.cho
+++ b/songs/folsom_prison_blues.cho
@@ -1,0 +1,24 @@
+
+{t:Folsom Prison Blues}
+{st:Johnny Cash}
+
+I [F]hear the train a-comin'; it's rollin' 'round the bend,
+And [F]I ain't seen the sunshine since I don't know [F7]when,
+I'm [A#7]stuck at Folsom Prison and time keeps draggin' [F]on.
+But that [C7]train keeps a-rollin' on down to San An[F]tone.
+
+When [F]I was just a baby, my momma told me, "Son,
+Always be a good boy; don't ever play with [F7]guns."
+But I [A#7]shot a man in Reno, just to watch him [F]die.
+When I [C7]hear that whistle blowin', I hang my head and [F]cry.
+
+I [F]bet there's rich folk eatin'in a fancy dining car.
+They're [F]prob'ly drinkin' coffee and smokin' big ci[F7]gars,
+But I [A#7]know I had it comin', I know I can't be [F]free,
+But those [C7]people keep a-movin', and that's what tortures [F]me.
+
+Well if they [F]freed me from this prison, if that railroad train was mine,
+I [F]bet I'd move it all a little farther down the [F7]line,
+[A#7]Far from Folsom Prison, that's where I'd want to [F]stay,
+And I'd [C7]let that lonesome whistle blow my blues [F]away.
+

--- a/songs/give_a_little_bit.cho
+++ b/songs/give_a_little_bit.cho
@@ -1,0 +1,27 @@
+
+{t:Give a Little Bit}
+{st:Supertramp}
+
+[A7] [D] oo yeah [A7] [D] [G] [A7] all right [G] [A7] here we go again [G]
+[D] [A7] [D] [G] yeah hey [A7] whoa no  na [G] na  hey hey [A7] [G]
+
+[A7] [D]Give a little bit, [A7] [D]give a little bit of [G]your [A7]love to me. [G] [A7] [G]
+[D] I'll give a little bit, [A7] [D]I'll give a little bit of [G]my [A7]love to you. [G] [A7] [G]
+[Bm]There's so much that we [E]need to share, so [G]send a smile and [A7]show you care.
+
+I'll [D]give a little bit, [A7] [D]I'll give a little bit of [G]my [A7]life for you. [G] [A7] [G]
+[D]So give a little bit, [A7] [D]oh, give a little bit of [G]your [A7]time to me. [G] [A7] [G]
+[Bm]See the man with the [E]lonely eyes, oh [G]take his hand, you'll [A7]be surprised.
+
+Ooooh take it.[F#m] (sax solo) [Bm]
+[F#m]Oh, yeah [Bm]
+Come along![F#m] [G] yeah yeah yeah yeah [C] yeah yeah [G] yeah yeah
+[A]
+Love...
+
+[D]Give a little bit, [A7] [D]oh give a little bit of [G]your [A7]love to me. [G] [A7] [G]
+[D] I'll give a little bit, [A7] [D]I'll give a little bit of [G]my [A7]life for you. [G] [A7] [G]
+[Bm]Now's the time that we [E]need to share, so [G]find yourself, we're [A7]on our way back home.
+
+...
+

--- a/songs/gold_dust_woman.cho
+++ b/songs/gold_dust_woman.cho
@@ -1,0 +1,54 @@
+{t:Gold Dust Woman}
+{st:Fleetwood Mac}
+#----------------------------------PLEASE NOTE---------------------------------#
+#This file is the author's own work and represents their interpretation of the #
+#song. You may only use this file for private study, scholarship, or research. #
+#------------------------------------------------------------------------------##
+#From: lirettej@nbnet.nb.ca (Jacques Lirette)
+#Subject: TAB:gold dust woman/fleet.mac
+#
+#This cool little tune is tuned down to dropped-D tuning (low E to a D)
+#Licics are pretty complicated to sing so listen to the tape frist...
+#
+#ok, here goes...
+#
+#Main Chords..(I'm not sure about the G, right fingering, wrong frets
+#mabey, try it within one fret of the ones posted) 
+#   D    C   G   A
+#---2----0---4---1
+#---3----1---4---3
+#---2----2---5---3
+#---0----0---0---3
+#---0----3---6---0
+#---0----x---6---x
+#
+#Opening rift: do twice then verse:starting with a upstroked D
+#---x---x--------    (Always twice)
+#---3---3--3-3/5-
+#---2---2--2-2/4-
+#---0---0--------
+#----------------
+#----------------
+#-0---0---0------
+                
+[D]Rock on Gold dust w[G]oman [C]take your silver [G]spoon,
+And dig your [D]grave...
+[D]  Heartless [G]challenge, [C]pick your [G]path, and I'll [D]pray
+[D]Wake up in the m[G]orning, see your [C] sunrise[G], lovers go do[D]wn.
+[D] Lousy lovers [G]pick their pray[C], but they'll never [G]cry out lo[D]ud.
+
+Chrous:
+[A]Did she make you cry? [G]Make you break down? [C]Shatter your illusions of [D]love?
+[A]Is it over now? [G]Do you know how? [C]To pick up the pieces and go ho[D]me...
+
+[D]Rock on ancient [G]queen, [C]follow those who [G]pale in your sha[D]dow...
+[D]Rulers make bad [G]lovers, [C]You better put your [G]kingdom up for sale..
+
+Chrous x2 w/ variation in second:'illusions of love now tell me is it...'
+
+#The lyrics are correct(out of the CD cover) so no problems there, but
+#again singing the first little bit is weird as it changes each verse...
+#A cool tune nonetheless....
+#                           Till peanuts fall out of my ears,
+#                                        A.Elaschuk
+#50cent TOUR:Moncton's newest band!!!!!!

--- a/songs/heart_of_gold.cho
+++ b/songs/heart_of_gold.cho
@@ -1,0 +1,46 @@
+{t:Heart Of Gold}
+{st:Neil Young}
+
+{comment: intro chords x2: Em7 D Em7}
+
+{comment: 3x Em C D G (harmonica solo)}
+
+{comment: Em7 D Em7}
+
+[Em] I want to [C]live [D] I want to [G]give
+[Em] I've been a [C]miner    for a [D]heart of [G]gold
+[Em] It's these ex[C]pressions [D] I never [G]give
+[Em7] That keeps me searching for a [G]heart of gold
+[C] and im getting old  [G]
+[Em7] keeps me searching for a [G]heart of gold
+[C] and im getting old [G]
+#Riff
+#-----------3------------------
+#-----------0------------------
+#-----------0------------------
+#-----------0------------------
+#--3--2--0--2------------------
+#-----------3------------------
+
+{comment: 3x Em C D G (harmonica solo)}
+{comment: Em7 D Em7}
+
+[Em] I've been to [C]Hollywood [D] I've been to [G]redwood
+[Em] I've crossed the [C]ocean for a [D]heart of [G]gold
+[Em] I've been in [C]my mind [D]it's such a [G]fine line.
+[Em7] That keeps me searching for a [G]heart of gold
+[C] and im getting old [G]
+[Em7] That keeps me searching for a [G]heart of gold
+[C] and im getting old [G]
+
+{colb}
+{comment: 3x Em C D G (harmonica solo)}
+
+[Em7]Keep me searching for a [D]heart of [Em7]gold
+You [Em7]keep me searching and I'm [D]growin' [Em7]old
+[Em7]Keep me searching for a [D]heart of [Em7]gold
+[Em7]I've been a miner for a [G]heart of gold
+
+[C] [G]
+Ahh...
+

--- a/songs/hey_there_delilah.cho
+++ b/songs/hey_there_delilah.cho
@@ -1,0 +1,68 @@
+
+{t:Hey There Delilah}
+{st:Plain White T's}
+
+{define: D x x 0 2 3 x}
+{define: F#m x x 4 2 2 x}
+{define: Bmin x 2 4 4 3 2}
+
+INTRO
+[D] [F#m] [D] [F#m]
+
+VERSE 1
+[D]Hey there Delilah, What's it [F#m]like in New York City? 
+I'm a [D]thousand miles away, But girl to[F#m]night you look so pretty, 
+Yes you [Bm]do, [G]Time Square can't [A]shine as bright as [Bm]you, 
+I swear it's [A]true. 
+[D]Hey there Delilah, Don't you [F#m]worry about the distance, 
+I'm right [D]there if you get lonely, Give this [F#m]song another listen, 
+Close your [Bm]eyes, [G]Listen to my [A]voice it's my dis[Bm]guise, 
+I'm by your [A]side. 
+
+CHORUS
+[D]Oh it's what you do to [Bm]me, [D]Oh it's what you do to [Bm]me, 
+[D]Oh it's what you do to [Bm]me, [D]Oh it's what you do to [Bm]me, 
+What you do to [D]me. 
+
+VERSE 2
+[D]Hey there Delilah, I know [F#m]times are getting hard, 
+But just be[D]lieve me girl some day, I'll pay the [F#m]bills with this guitar,
+We'll have it [Bm]good, [G]We'll have the [A]life we knew we [Bm]would, 
+My word is [A]good. 
+
+[D]Hey there Delilah, I've got [F#m]so much left to say, 
+If every [D]simple song I wrote to you, Would [F#m]take your breath away, 
+I'd write it [Bm]all, [G]Even more in [A]love with me you'd [Bm]fall, 
+We'd have it [A]all. 
+{colb}
+
+CHORUS
+[D]Oh it's what you do to [Bm]me, [D]Oh it's what you do to [Bm]me, 
+[D]Oh it's what you do to [Bm]me, [D]Oh it's what you do to [Bm]me, 
+
+Bridge
+[G]A thousand miles seems pretty far, But
+[A]they've got planes and trains and cars,
+[D]I'd walk to you if I had no other [Bm]way
+[G]Our friends would all make fun of us, And
+[A]we'll just laugh along because, 
+We [D]know that none of them have felt this [Bm]way,
+[G]Delilah I can promise you, That [A]by the time that we get through, 
+The [Bm]world will never ever be the same, And you're to [A]blame. 
+
+VERSE 3
+[D]Hey there Delilah you be [F#m]good, And don't you miss me,
+Two more [D]years and you'll be done with school, And
+[F#m]I'll be making history, 
+[Bm]Like I do, [G]You'll know it's [A]all because of [Bm]you, 
+[G]We can do what[A]ever we want [Bm]to, 
+[G]Hey there De[A]lilah here's to [Bm]you, This one's for [A]you. 
+
+FINAL CHORUS
+[D]Oh it's what you do to [Bm]me, [D]Oh it's what you do to [Bm]me,
+[D]Oh it's what you do to [Bm]me, [D]Oh it's what you do to [Bm]me,
+What you do to [D]me.
+
+[Bm] [D] [Bm] [D] [Bm] [D] [Bm] [D] [D]
+Ohhh 
+

--- a/songs/high_and_dry.cho
+++ b/songs/high_and_dry.cho
@@ -1,0 +1,37 @@
+{title:High and Dry}
+{subtitle:Radiohead}
+
+{comment: Play Capo 2 to match album track}
+
+
+[Em]        [G]        [D]
+[Em]        [G]        [D]
+
+[Em]Two jumps in a week, I bet you th[G]ink that's pretty clever don't [D]you boy?
+[Em]Flying on your motorcycle, [G]watching all the ground beneath [D]you drop 
+[Em]You'd kill yourself for recognition, [G]kill yourself to never, [D]ever stop  [D]
+[Em]You broke another mirror, you're [G]turning into something you [D]are not
+
+[D]Don't leave me [Em]high, [G] don't leave me [D]dry 
+[D]Don't leave me [Em]high, [G] don't leave me [D]dry 
+
+[Em]     [G]      [D]
+
+[Em]Drying up in conversation, [G]you'll be the one who can[D]not talk 
+[Em]All your insides fall to pieces, [G]you just sit there wishing you could still [D]make love
+[Em]They're the ones who'll hate you when you [G]think you've got the world all [D]sussed out
+[Em]They're the ones who'll spit on you, [G]you will be the one [D]screaming out 
+[D]Don't leave me [Em]high, [G] don't leave me [D]dry 
+[D]Don't leave me [Em]high, [G] don't leave me [D]dry 
+
+[Em] (solo)    [G]      [D]
+[Em] (solo)    [G]      [D]
+
+Oh, it's the [Em]best thing that you ever had, the [G]best thing that you ever, e[D]ver had. 
+It's the [Em]best thing that you ever had, the [G]best thing you have had has go[D]ne away. 
+
+So don't leave me [Em]high, [G] don't leave me [D]dry 
+Don't leave me [Em]high, [G] don't leave me [D]dry 
+Don't leave me [Em]high, [G] (guitar solo)
+Don't leave me [Em]high, [G] don't leave me [D]dry 
+

--- a/songs/horse.cho
+++ b/songs/horse.cho
@@ -1,0 +1,58 @@
+{t:Horse}
+{st:Live}
+
+{comment:Album track is tuned down a whole step}
+
+[G] All the [F]things that they make you [E]say
+[G] All the [F]love that you hide [E]away
+[G] I'll pick you [F]up and it'll be al[E]right
+[G] I'll pick you [F]up and it'll be to[E]night
+
+
+chorus
+[G] She rode a [Bm]horse into my he[F]ad... [G]
+[G] She rode a [Bm]horse into my he[F]ad... [G]yeah
+[G] She won't [Bm]discipline the chil[F]dren... [G]
+[G] And now they're [Bm]running' wild on the [F]beach...
+and I don't [G]care
+
+No, [Asus2]I don't care
+No, [Asus2]I don't care
+No, [Asus2]I don't care, hey hey.
+
+[G] It's the [F]middle of the night and we're [E]here
+[G] Playin' [F]dominos and drinkin' [E]beer
+[G] I try to [F]think of something deep to say[E]
+[G] but my [F]well is dippin' dry to[E]day, hey, hey hey [G]hey
+
+
+(Chorus but slightly different:)
+[G] She rode a [Bm]horse into my he[F]ad... [G]
+[G] She rode a [Bm]horse into my he[F]ad... [G]my head
+[G] She won't [Bm]discipline the chil[F]dren... oh, [G]no
+[G] And now they're [Bm]running' wild on the [F]beach...
+and I don't [G]care
+{colb}
+
+No, [Asus2]I don't care
+No, [Asus2]I don't care
+No, [Asus2]I don't care, hey hey.
+
+Verse with guitar solo...
+G F E
+G F E
+G F E
+G F E
+
+{comment:Chorus, hold Asus2 on last "care"}
+
+[G] She rode a [Bm]horse into my he[F]ad... [G]
+[G] She rode a [Bm]horse into my he[F]ad... [G]my head
+[G] She won't [Bm]discipline the chil[F]dren... oh, [G]no
+[G] And now they're [Bm]running' wild on the [F]beach...
+and I don't [G]care
+
+No, [Asus2]I don't care
+No, [Asus2]I don't care
+No, [Asus2]I don't care...
+

--- a/songs/horse_with_no_name.cho
+++ b/songs/horse_with_no_name.cho
@@ -1,0 +1,56 @@
+
+{even}
+{title:Horse With No Name}
+{subtitle:America}
+
+{define:Em 0 2 2 0 0 0}
+{define:Dadd6add9 2 0 0 2 0 0}
+
+[Em] [Dadd6add9]
+[Em] [Dadd6add9]
+
+On the [Em]first part of the [Dadd6add9]journey
+I was [Em]lookin' at all the [Dadd6add9]life
+There were [Em]plants and birds and [Dadd6add9]rocks and things
+There was [Em]sand and hills and [Dadd6add9]rings
+
+The [Em]first thing I met was a [Dadd6add9]fly with a buzz
+and a [Em]sky with no [Dadd6add9]clouds
+the [Em]heat was hot and the [Dadd6add9]ground was dry
+but the [Em]air was full of [Dadd6add9]sound
+
+{comment:Chorus:}
+
+{soc}
+I've [Em]been through the desert on a [Dadd6add9]horse with no name
+It felt [Em]good to be out of the [Dadd6add9]rain
+In the [Em]desert, you can [Dadd6add9]remember your name
+'Cause there [Em]ain't no one for to [Dadd6add9]give you no pain.
+La [Em]la la la-a[Dadd6add9]-la-la-la la la [Em]la la [Dadd6add9]la
+La [Em]la la la-a[Dadd6add9]-la-la-la la la [Em]la la [Dadd6add9]la
+{eoc}
+
+After [Em]two days in the [Dadd6add9]desert sun
+My [Em]skin began to turn [Dadd6add9]red
+After [Em]three days in the [Dadd6add9]desert fun
+I was [Em]lookin' at a river [Dadd6add9]bed
+And the [Em]story it told of a [Dadd6add9]river that flowed
+Made me [Em]sad to think it was [Dadd6add9]dead.
+
+{comment:Chorus}
+
+{comment:Acoustic Guitar Solo}
+
+{colb}
+
+After [Em]nine days, I let the [Dadd6add9]horse run free,
+'cause the [Em]desert had turned to [Dadd6add9]sea.
+There were [Em]plants and birds and [Dadd6add9]rocks and things
+There was [Em]sand and hills and [Dadd6add9]rings
+The [Em]ocean is a desert with its [Dadd6add9]life underground
+and the [Em]perfect disguise a[Dadd6add9]bove
+Under the [Em]cities lies a [Dadd6add9]heart made of ground
+but the [Em]humans will give no [Dadd6add9]love.
+
+{comment:Chorus}
+

--- a/songs/hotel_california.cho
+++ b/songs/hotel_california.cho
@@ -1,0 +1,50 @@
+
+{even}
+{t:Hotel California}
+{st:Eagles}
+
+[Am]On a dark desert highway, [E]cool wind in my hair
+[G]Warm smell of colitas, [D]rising up through the air
+[F]Up ahead in the distance, [C]I saw a shimmering light
+[Dm]My head grew heavy and my sight grew dim, [E]I had to stop for the night
+
+[Am]There she stood in the doorway, [E]I heard the mission bell
+[G]And I was thinking to myself: this could be [D]heaven or this could be hell
+[F]Then she lit up a candle [C]and she showed me the way
+[Dm]There were voices down the corridor; [E]I thought I heard them say:
+
+Chorus:
+[F]Welcome to the Hotel Califor[C]nia
+[E]Such a lovely place (such a lovely place), such a [Am]lovely face
+[F]Plenty of room at the Hotel Cali[C]fornia
+Any [Dm]time of year (any time of year), you can [E]find it here.
+# {colb}
+
+[Am]Her mind is Tiffany twisted, [E]she got the Mercedes Benz
+[G]She got a lot of pretty, pretty boys, [D]that she calls friends
+[F]How they dance in the courtyard, [C]sweet summer sweat.
+[Dm]Some dance to remember, [E]some dance to forget.
+
+[Am]So I called up the captain, "[E]Please bring me my wine", He said
+[G]"We haven't had that spirit here since [D]nineteen sixty-nine".
+[F]And still those voices are calling from [C]far away
+[Dm]Wake you up in the middle of the night, [E]just to hear them say:
+
+Chorus:
+[F]Welcome to the Hotel Califor[C]nia
+[E]Such a lovely place (such a lovely place), such a [Am]lovely face
+[F]They livin' it up at the Hotel Cali[C]fornia
+[E]What a nice surprise (such a nice surprise), when you're [Am]alibis.
+
+[Am]Mirrors on the ceiling, [E]the pink champagne on ice, and she said
+[G]"We are all just prisoners here, [D]of our own device"
+[F]And in the master's chambers, [C]they gathered for the feast
+[Dm]They stab it with their steely knives but they [E]just can't kill the beast
+
+[Am]Last thing I remember, I was [E]running for the door
+[G]   I had to find the passage back to the [D]place I was before
+"[F]Relax," said the night man, "We are [C]programmed to receive
+[Dm]You can check out any time you like, but [E]you can never leave"
+
+If desired, solo over verse chords as many times as you want
+

--- a/songs/im_in.cho
+++ b/songs/im_in.cho
@@ -1,0 +1,70 @@
+{t:I'm In}
+{st:The Kinleys}
+
+{c:Instrumental intro}
+G D Am C
+G D Am C
+
+[G]Love doesn't [D]come with a [Am]contract.
+[G]You give me [D]this, I give you [Am]that.
+[C]It's scary business,
+[G]Your heart and soul is on the [C]line.
+Baby, why else would I be stand[D]ing round here
+so tongue-tied?
+ 
+{soc}
+{c:Chorus}
+
+If I [G]knew what I was [D]doing,
+I'd be [Am]doing it right [C]now.
+I would [G]be the best damn [D]poet
+Silver [Am]words out of my [C]mouth.
+Well my [Em]words might not be [D]magic,
+But they [C]cut straight to the truth.
+So [Am]if you need a [G]lover and a [C]friend,  [D]
+Baby I'm [G]in, I'm [D]in, I'm [Am]in, I'm [C]in...
+Baby I'm [G]in, I'm [D]in, I'm [Am]in, I'm [C]in...
+{eoc}
+ 
+ 
+[G]Baby come on [D]in, the water's [Am]fine.
+[G]I'll be right [D]here, you take your [Am]ti-me.
+[C]Just let me hold you,
+[G]And we'll both take that leap of [C]faith.
+It's like I told you, there's no [D]guarantee
+when you feel this way.
+
+{colb}
+
+{c:Repeat Chorus}
+ 
+{sob}
+{c:Bridge}
+
+[G]Baby come here next to me,
+I'll [D]show you how good it can be.
+I'll [Am]breathe each breath you breathe I can
+[C]Pour out every[D]thing I am.
+{eob}
+
+{c:Solo}
+C G Bb D
+ 
+If I [G]knew what I was [D]doing,
+I'd be [Am]doing it right [C]now.
+I would [G]be the best damn [D]poet
+Silver [Am]words out of my [C]mouth.
+Well my [Em]words might not be [D]magic,
+But they [C]cut straight to the truth.
+So [Am]if you need a [G]lover and a [C]friend,
+If you need a [G]lover,
+So [Am]if you need a [G]lover and a [C]friend,  [D]
+Bayy I'm baby I'm baby I'm [G]in, I'm [D]in, I'm [Am]in, I'm [C]in...
+Baby I'm [G]in, I'm [D]in, I'm [Am]in, I'm [C]in...
+ 
+{c:Repeat Bridge}
+
+{c:Repeat Bridge Chords x2}
+
+{c:Fade out}
+

--- a/songs/in_between_days.cho
+++ b/songs/in_between_days.cho
@@ -1,0 +1,29 @@
+{title:In Between Days}
+{subtitle:The Cure}
+# http://www.tabpower.com/s3813.html
+
+{define: Dmaj7 x x 0 2 2 2}
+{define: Bm9 x 2 0 2 2 2}
+
+[A]Yesterday I[Dmaj7] got so old [A]I felt like I could [D]die
+[A]Yesterday I[D] got so old [A]it made me wanna cr[D]y
+
+[A]Go on go on just [D]walk away
+[A]Go on go on your [D]choice is made
+[A]Go on go on and [D]disappear
+[A]Go on go on a[D]way from here
+
+And I [Bm9]know I was wrong when I [E]said it was true
+That it [Bm]couldn't been me and with [E]her in between without [A]you
+
+[A]Yesterday I[Dmaj7] got so scared I[A] shivered like a chil[D]d
+[A]Yesterday a[D]way from you [A]it froze me deep insid[D]e
+
+[A]Come back come back don't [D]walk away
+[A]come back come back come [D]back today
+[A]come back come back why can't [D]you see
+[A]come back come back come back [D]to me
+
+And I [Bm9]know I was wrong when I [E]said it was true
+That it [Bm]could've been me and with [E]her in between without [A]you
+

--- a/songs/in_spite_of_ourselves.cho
+++ b/songs/in_spite_of_ourselves.cho
@@ -1,0 +1,59 @@
+{t:In Spite of Ourselves}
+{st:John Prine and Iris Dement}
+
+[C]She don’t like her eggs all runny
+[C]She thinks crossin’ her legs is funny
+[F]She looks down her nose at money
+[C]She gets it on like the Easter Bunny
+[G]She’s my baby, I’m her honey
+Never gonna let her [C]go
+
+[C]He ain’t been laid in a month of Sundays
+[C]Caught him once and he was sniffin’ my undies
+[F]Ain’t too sharp but he gets things done
+[C]Drinks his beer like it’s oxygen
+[G]He’s my baby, I’m his honey
+Never gonna let him [C]go
+
+In spite of our[F]selves, we’ll end up sittin’ on a [C]rainbow.
+Against all [G]odds, honey we’re the big door [C]prize.
+We’re gonna [F]spite our noses right off of our [C]faces.
+There won’t be nothin’ but big ol’ [G7]hearts dancin’ in our [C]eyes.
+
+Solo
+[F] [C]
+[F] [C]
+[F] [C]
+[G7] [C]
+
+{colb}
+
+[C]She thinks all my jokes are corny
+[C]Convict movies make her horny
+[F]She likes ketchup on her scrambled eggs
+[C]Swears like a sailor when she shaves her legs
+[G]She takes a lickin’, and keeps on tickin’
+Never gonna let her [C]go
+
+[C]He’s got more balls than a big brass monkey
+[C]He’s a wacked-out weirdo and a love bug junkie
+[F]Sly as a fox, crazy as a loon
+[C]Payday comes and he’s a-howlin’ at the moon
+[G]He’s my baby, don’t mean maybe
+Never gonna let him [C]go
+
+In spite of our[F]selves, we’ll end up sittin’ on a [C]rainbow.
+Against all [G]odds, honey we’re the big door [C]prize.
+We’re gonna [F]spite our noses right off of our [C]faces.
+There won’t be nothin’ but big ol’ [G7]hearts dancin’ in our [C]eyes.
+
+In spite of our[F]selves, we’ll end up sittin’ on a [C]rainbow.
+Against all [G]odds, honey we’re the big door [C]prize.
+We’re gonna [F]spite our noses right off of our [C]faces.
+There won’t be nothin’ but big ol’ [G7]hearts dancin’ in our [C]eyes.
+There won’t be nothin’ but big ol’ [G7]hearts dancin’ in our [C]eyes.
+
+[C] [G7] [C] [C]
+
+Congratulations Jessie May and Stu!
+

--- a/songs/island_in_the_sun.cho
+++ b/songs/island_in_the_sun.cho
@@ -1,0 +1,93 @@
+{even}
+{title:Island in the Sun}
+{subtitle:Weezer}
+
+Strum Guide
+{sot}
+Em        Am      D          G
+D   D U D   D U   U   U D   D U
+1 + 2 + 3 + 4 + 1 + 2 + 3 + 4 +
+{eot}
+
+Main Riff:
+{sot}
+    Em         Am      D           G
+E|--3--3--x--5--x--2--2-2--x--3--3--
+B|--5--5--x--5--x--3--3-3--x--3--3--
+G|--4--4--x--5--x--2--2-2--x--4--4--
+D|----------------------------------
+A|----------------------------------
+E|----------------------------------
+{eot}
+
+Chorus Riff:
+{sot}
+     Em         Am         D         G
+e|-----------------------------------------|
+B|-----8---8---10--10----7---7----8---8----|
+G|---9---9----9---9----7---7----7---7------|
+D|-----------------------------------------|
+A|-----------------------------------------|
+E|-----------------------------------------|
+{eot}
+
+Intro:  Main Riff x4
+
+[Em] [Am]When you're [D]on a [G]holi-
+[Em]day [Am]You can't [D]find the [G]words to
+[Em]say [Am]All the[D] things that come[G] to
+[Em]you     [Am]And I wa[D]nt to feel[G] it
+
+Chorus (with chorus riff):
+
+[Em]too. [Am]On an i[D]sland i[G]n the
+[Em]sun [Am]We'll be pl[D]aying and [G]having
+[Em]fun [Am]And it mak[D]es me fe[G]el so
+[Em]fine I can'[Am]t contr[D]ol my [G]brain
+
+Main Riff x2
+
+[Em] [Am]When you're o[D]n a [G]golden
+[Em]sea [Am]You don't [D]need no me[G]mory
+[Em] [Am]Just a [D]place to [G]call your
+[Em]own [Am] As we [D]drift in[G]to the
+
+Chorus:
+[Em]zone. [Am]On an i[D]sland i[G]n the
+[Em]sun [Am]We'll be pl[D]aying and [G]having
+[Em]fun [Am]And it mak[D]es me fe[G]el so
+[Em]fine I can'[Am]t contr[D]ol my [G]brain
+
+Bridge:
+[D5] We'll run a[G5]way together
+[D5] We'll spend some [G5]time forever
+[C5] We'll never [A5]feel bad any[D5]more
+
+Main Riff x2
+
+Solo (x2) w/main riff:
+{sot}
+E|-10------------------------------------------------------
+B|----------------------------------------------------------
+G|------9--7------------------------------------------------
+D|------------10--9----10--9------9--7----------------------
+A|-----------------------------10--------10--9---10---10--10
+E|----------------------------------------------------------
+{eot}
+
+Chorus
+[Em]  [Am]On an i[D]sland i[G]n the
+[Em]sun [Am]We'll be pl[D]aying and [G]having
+[Em]fun [Am]And it mak[D]es me fe[G]el so
+[Em]fine I can'[Am]t contr[D]ol my [G]brain
+
+Bridge:
+[D5] We'll run a[G5]way together
+[D5] We'll spend some [G5]time forever
+[C5] We'll never [A5]feel bad any[D5]more
+
+Play Main Progression x6
+sing "We'll never feel bad anymore" during 2nd and 5th repetitions
+
+Hold last G
+

--- a/songs/jumper.cho
+++ b/songs/jumper.cho
@@ -1,0 +1,69 @@
+
+{even}
+{t:Jumper}
+{st:Third Eye Blind}
+
+{define: Fmaj7 x 3 3 2 1 0}
+{define: D9sus2 x 5 4 0 3 0}
+
+[Fmaj7]I wish you would [C]step back from that [G]ledge, my friend.
+You could [Fmaj7]cut ties with [C]all the lies that [G]you've been livin' in.
+[Fmaj7]And if you do [C]not want to see [G]me again,
+I would underst[Fmaj7]a-[C]a-[G]and.
+I would underst[Fmaj7]a-[C]a-[G]and.
+
+The [Am]angry boy a bit too insane
+[C]icing over a secret pain.
+[G]You know you don't belong.
+
+You're the [Am]first to fight.  You're way too loud.
+You're the [C]flash of light on a burial shroud.
+[G]I know something's wrong.
+
+Well [Am]everyone I know has got a [D9sus2]reason to [C]say
+Put the past a[Fmaj7]way.
+
+I wish you would [C]step back from that [G]ledge, my friend.
+You could [Fmaj7]cut ties with [C]all the lies that [G]you've been livin' in.
+[Fmaj7]And if you do [C]not want to see [G]me again,
+I would underst[Fmaj7]a-[C]a-[G]and.
+I would underst[Fmaj7]a-[C]a-[G]and.
+
+Well he's [Am]on the table and he's goin' to code.
+I do not [C]think anyone knows what they're [G] doin' here.
+And your [Am]friends have left you, you've been dismissed.
+[C]I never thought it would come to this and I[G], I want you to know.
+[Am]Everyone's got to face down the [D9sus2]demons.  Maybe to[C]day you can
+Put the past a[Fmaj7]way.
+
+[Fmaj7]I wish you would [C]step back from that [G]ledge, my friend.
+You could [Fmaj7]cut ties with [C]all the lies that [G]you've been livin' in.
+[Fmaj7]And if you do [C]not want to see [G]me again,
+I would underst[Fmaj7]a-[C]a-[G]and.
+I would underst[Fmaj7]a-[C]a-[G]and.
+I would underst[Fmaj7]a-[C]a-[G]and.
+
+# {comment:instrumental, mostly bass and drums Fmaj7 C G}
+# {comment:Fmaj7 C G(I would understand)}
+# {comment:Fmaj7 C G(I would understand)}
+# {comment:Fmaj7 C G(understand)}
+# {comment:Fmaj7 C G}
+# {comment:Fmaj7 C G}
+# 
+# {comment: Repeat 2 times, louder}
+# {comment:Fmaj7 C G}
+# {comment:Fmaj7 C G}
+# 
+# {comment: Repeat 4 times, full volume}
+# {comment:Fmaj7 C G}
+# {comment:Fmaj7 C G}
+# {comment:Fmaj7 C G}
+# {comment:Fmaj7 C G}
+# 
+# [D9sus2] [C]Can you put the past a[Fmaj7]way?
+# 
+# {comment: Repeat 5 times:}
+# [Fmaj7]I wish you would [C]step back from that [G]ledge, my friend. (I would understand)
+# 
+# {comment:Fmaj7 C G fade out to snare drum}
+

--- a/songs/last_train_to_clarksville.cho
+++ b/songs/last_train_to_clarksville.cho
@@ -1,0 +1,66 @@
+{t:Last Train to Clarksville}
+{st:The Monkees}
+
+Intro:
+4x G7 riff with tambourine
+
+[G7]Take the last train to Clarksville
+[G7]and I'll meet you at the station
+[G7]You can be here by four-thirty
+[G7]'cause I've made your reservation
+Don't be [C7]slow, oh no-no-no, oh no-no-no...
+
+(break)
+
+[G7]'Cause I'm leavin' in the morning,
+[G7]and I must see you again.
+[G7]We'll have one more night together
+[G7]'til the morning brings my train.
+and I must [C7]go, oh no-no-no, oh no-no-no...
+
+(break)
+
+[D7]And I don't know if I'm ever comin' [G7]home.
+
+2x G7 
+
+[G7]Take the last train to Clarksville
+[G7]I'll be waiting at the station.
+[G7]We'll have time for coffee-flavored kisses
+[G7]And a bit of
+conversation, [C7] oh...
+oh no-no-no, oh no-no-no...
+
+(break)
+
+{colb}
+
+[G7]Take the last train to Clarksville
+[G7]now I must hang up the phone
+[G7]I can't hear you in this noisy railroad station
+[G7]all alone
+I'm feeling [C7] low
+oh no-no-no, oh no-no-no...
+
+(break)
+
+[D7]And I don't know if I'm ever comin' [G7]home.
+
+(break)
+
+[G7]Take the last train to Clarksville
+[G7]and I'll meet you at the station
+[G7]You can be here by four-thirty
+[G7]'cause I've made your reservation
+Don't be [C7]slow, oh no-no-no, oh no-no-no...
+
+[D7]And I don't know if I'm ever comin' [G7]home.
+
+(break)
+
+2x riff
+
+[G7]Take the last train to Clarksville  (oo-oo-oo-oo)
+[G7]Take the last train to Clarksville!  (oo-oo-oo-oo)
+(repeat with riff and fade out)
+

--- a/songs/learning_to_fly.cho
+++ b/songs/learning_to_fly.cho
@@ -1,0 +1,63 @@
+
+{t:Learning To Fly}
+{st:Tom Petty}
+#
+#one guitar plays
+#[F]    [C]    [Am]    [G]
+#The other guitar plays
+#{start_of_tab}
+#--------------------------------------------------------------------------
+#------1---1-----1---1--0--1-0-1----1--1---1----1-----1-0--1-0-1-----------
+#-2-0----0---0-0---0-------------2-0--0-0-0---0----0-----------------------
+#--------------------------------------------------------------------------
+#--------------------------------------------------------------------------
+#--------------------------------------------------------------------------
+#{end_of_tab}
+
+[G]Well, I [F]started [C]out [Am] [G] 
+Down a [F]dirty [C]road [Am] [G]
+[F]Started [C]out [Am] [G] 
+[F]All [C]alone  [Am] [G]
+
+And the [F]sun went [C]down   [Am] [G]
+as I [F]crossed the [C]hill  [Am] [G]
+And the [F]town lit [C]up  [Am] [G]
+And the [F]world got [C]still  [Am] [G]
+
+{start_of_chorus}
+I'm [F]learning to [C]fly [Am](learning to [G]fly)
+but I [F]ain't got [C]wings [Am](learning to [G]fly)
+[F]coming [C]down [Am](learning to [G]fly)
+is the [F]hardest [C]thing [Am] [G]
+{end_of_chorus}
+
+Well the [F]good old [C]days [Am] [G]
+may [F]not re[C]turn  [Am] [G]
+And the [F]rocks might [C]melt [Am] [G]
+And the [F]sea may [C]burn [Am] [G]
+
+{colb}
+{comment:Chorus}
+
+Well, [F]some say [C]life  [Am] [G]
+will [F]beat you [C]down [Am] [G]
+[F]break your [C]heart [Am] [G]
+[F]steal your [C]crown [Am] [G]
+
+so I've [F]started [C] out  [Am](ooh, [G]ooh)
+for [F]God knows [C]where  [Am](ooh, [G]ooh)
+I [F]guess I'll [C]know [Am](ooh, [G]ooh)
+when [F]I get [C]there [Am](ooh, [G]ooh)
+
+{comment:Chorus}
+
+I'm [F]learning to [C]fly [Am](learning to [G]fly) 
+a[F]round the [C]clouds [Am] [G]
+[F]what goes [C]up [Am](learning to [G]fly)
+[F]must come [C]down [Am] [G]
+
+I'm [F]learning to [C]fly [Am](learning to [G]fly)
+I'm [F]learning to [C]fly [Am](learning to [G]fly)
+I'm [F]learning to [C]fly [Am](learning to [G]fly)
+I'm [F]learning to [C]fly
+

--- a/songs/let_her_cry.cho
+++ b/songs/let_her_cry.cho
@@ -1,0 +1,72 @@
+
+#----------------------------------PLEASE NOTE---------------------------------#
+#This file is the author's own work and represents their interpretation of the #
+#song. You may only use this file for private study, scholarship, or research. #
+#------------------------------------------------------------------------------##
+#From: vetters@vax1.elon.edu (Steve Vetter)
+#
+{t:Let her Cry}
+{st:Hootie and The Blowfish}
+#tabbed by Steve Vetter [vetters@vax1.elon.edu]
+#
+#Chords:  G D C
+
+Riff during chorus:
+B---10--12---repeat
+
+#From: rds@zk3.dec.com
+#
+#(Note - this version has corrected lyrics and performance notes)
+#
+#Let her Cry - Hootie & The Blowfish
+#charted by Rick Schofield (rds@mv.mv.com)
+#
+VERSE 1:
+[G]She sits alone by a lamp-[D]post
+[C]Trying to find a thought that's escaped her [G]mind
+[G]She says there's the one[D] I love the most
+[C]his type's not far be[G]hind
+
+[G]She never lets me in	[D]only tells me where she's been
+[C]when she's had to much to [G]drink
+[G]I say that I don't care. [D] I just run my hands through her dark hair
+[C]then I pray to God, "You gotta help me [G]fly away"   (and just)
+
+CHORUS:
+let her [C]cry	if the [G]tears fall down like rain
+let her [C]sing	If it [Em]eases [G]all her [D]pain
+let her [C]go	let her [G]walk right out on me
+and if the [D]sun comes up tomorrow, 
+let her [C]be,   let her [G]be
+
+[G] [D] [C] [G]
+
+(4 bars solo)
+
+{colb}
+VERSE 2:
+[G]This morning I woke up alone    [D]found a note standing by the phone
+[C]saying "maybe, maybe I'll be [G]back someday"
+[G]I wanted to look for you
+you walked [D]in, I didn't know just what I should do
+So, I [C]sat back down, had a beer and felt [G]sorry for myself
+
+CHORUS
+
+(solo - 8 bars over verse)
+
+CHORUS
+
+VERSE 3:
+[G]last night I tried to leave
+[D]cried so much I could not beleive
+[C]she was the same girl I fell in love with [G]long ago
+[G]she went in the back to get high
+[D]I sat down on my couch and cried yelling
+[C]"Whoa Lord whoa, please help me.  Won't you [G]hold my hand"
+
+(chorus - ends differently as....)
+and if the [D]sun comes up tomorrow, let her [G]be
+
+CHORUS
+

--- a/songs/lithium.cho
+++ b/songs/lithium.cho
@@ -1,0 +1,66 @@
+{even}
+{t:Lithium}
+{st:Nirvana}
+
+{define: Abm 4 6 6 4 4 4}
+{define: C#m 4 4 6 6 5 4}
+
+Intro:
+
+[E] [Abm] [C#m] [A] [C] [D] [B] [D]
+
+Verse 1
+
+[E] [Abm]I'm so [C#m]happy [A]'cause to[C]day
+I [D]found my [B]friends
+They're [D]in my [E]head
+[Abm]I'm so [C#m]ugly, but [A]that's o[C]kay, 'cause [D]so are [B]you
+We [D]broke our [E]mirrors
+[Abm]Sunday [C#m]morning is [A]every[C]day for [D]all I [B]care
+And [D]I'm not [E]scared
+[Abm]Light my [C#m]candles, [A]in a [C]daze
+'Cause [D]I've found [B]god
+
+Chorus 1
+
+Yeah, yeah
+Yeah, yeah
+Yeah, yeah
+Yeah, yeah
+Yeah, yeah
+Yeah, yeah, yeah
+
+Verse 2
+
+I'm so lonely, that's ok I shaved my head
+And I'm not sad
+And just maybe I'm to blame for all I've heard
+And I'm not sure
+I'm so excited, I can't wait to meet you there
+But I don't care
+I'm so horny, but that's okay
+My will is good
+{colb}
+
+Chorus 2
+
+Yeah, yeah
+Yeah, yeah
+Yeah, yeah
+Yeah, yeah
+Yeah, yeah
+Yeah, yeah, yeah
+
+[A] I [C]like it - [A]I'm not [C]gonna [A]crack
+ I [C]miss you - [A]I'm not [C]gonna [A]crack
+ I [C]love you - [A]I'm not [C]gonna [A]crack
+I [C]kill you - [A]I'm not [C]gonna [A]crack
+I like it - I'm not gonna crack
+I miss you - I'm not gonna crack
+I love you - I'm not gonna crack
+I [C]kill you - [A]I'm not [C]gonna [D]crack [B]
+
+Repeat Verse 1
+
+Repeat Chorus 2
+

--- a/songs/lola.cho
+++ b/songs/lola.cho
@@ -1,0 +1,76 @@
+
+{even}
+{t:Lola}
+{st:by Ray Davies of the Kinks}
+
+{comment:Intro:}
+
+ [C]       [D]       [E]
+                                               
+I m[E]et her in a club down in old Soho
+Where you [A]drink champagne and it [D]tastes just like cherry [E]cola  C-O-L-A [A]cola [Asus4]
+She [E]walked up to me and she asked me to dance 
+I [A]asked her her name and in a [D]dark brown voice she said  
+[E]Lola  L-O-L-A [A]Lola [D]La la la la [C]Lo - la  [D]      [E]
+
+{comment:play riff}
+
+Well [E]I'm not the world's most physical guy, 
+but when she [A]squeezed me tight she nearly [D]broke my spine. 
+Oh my [E]Lola Lo Lo Lo Lo [A] Lola
+[E]Well I'm not dumb but I can't understand 
+why she [A]walked like a woman, but [D]talked like a man.
+[E]Oh my Lola, La La La La [A]Lola, [D]La La La La [C]Lola [D] [E]
+ 
+{comment:play riff}
+
+Well we dr[B]ank champagne and danced all night 
+[F#7]under electric candle light 
+She [A]picked me up and sat me on her knee and
+[A] said "dear boy won't you [A7]come home with me?" 
+
+Well, [E]I'm not the world's most passionate guy, 
+but when I [A]looked in her eyes, well I [D]almost fell for my 
+[E]Lola, La La La La [A]Lola, [D]La La La La [C]Lola [D]
+[E]Lola, La La La La [A]Lola, [D]La La La La [C]Lola [D] [E]
+
+{comment:play riff}
+                                               
+I [A]pushed [C#m]her a[B]way I [A]walked [C#m]to the [B]door  I [A]fell [C#m]to the [B]floor 
+I got [E]down [G#m]on my [C#m]knees Then [B]I looked at her and she at [B13]me  
+  
+[E]Well, that's the way that I wanted to stay... 
+I [A]always wanted to [D]be that way for my
+[E]Lola Lo Lo Lo Lo [A]Lola
+[E]Girls will be boys and boys will be girls, 
+It's a [A] mixed up, muddled up, [D]shook up world,
+Except for [E]Lola La Lo La La [A]Lola
+
+Well, [B]I'd left home just a week before,
+And [F#7]I'd never ever kissed a woman before.
+[A]Lola smiled and took me by the hand, 
+Said dear boy, gonna [A7]make you a man.
+
+[E]Well I'm not the world's most masculine man, 
+But I [A]know what I am, I'm a [D]man, I'm a man, so is [E]Lola.
+[E]Lola, La La La La [A]Lola, [D]La La La La [C]Lola [D]
+[E]Lola, La La La La [A]Lola, [D]La La La La [C]Lola [D]
+
+{comment:If desired, play with soloing}
+
+[E]Lola, La La La La [A]Lola, [D]La La La La [C]Lola [D]
+[E]Lola, La La La La [A]Lola, [D]La La La La [C]Lola [D]
+[E]Lola, La La La La [A]Lola, [D]La La La La [C]Lola [D]
+[E]Lola, La La La La [A]Lola, [D]La La La La [C]Lola [D]
+{comment:Trail off}
+
+#Riff played between verses:   
+#{start_of_tab}
+#      E--0000---0--4-2-0---------------------------                        
+#      B--5555---5-------2-0------------------------                        
+#      G--4444---4------------1------------4--46----                        
+#      D------------------------4 2-6--4-6---6------                        
+#      A--------------------------------------------                        
+#      E--------------------------------------------                        
+#{end_of_tab}
+

--- a/songs/long_ride_home.cho
+++ b/songs/long_ride_home.cho
@@ -1,0 +1,52 @@
+
+{t:Long Ride Home}
+{st:Patty Griffin}
+
+{comment: Capo 4}
+
+[D]Long black limousine
+[D]Shiniest car I've ever seen
+[G]Back seat is nice and clean
+[D]She rides as quiet as a dream
+
+[A]Someone dug a hole six long [G]feet in the [D]ground
+[A]I said goodbye to you and I [G]threw my roses [D]down
+[A]Gin't nothin' left at all in the [G]end of bein' [D]proud
+with me [G]ridin' in this car and you
+[A]flyin' through them clouds
+
+[G]I've had some time to think a[D]bout it
+[G]and watch the sun sink like a [D]stone
+[G]I've had some time to think [Bm]about you
+on the [A]long ride [D]home
+
+[D]One day I took your tiny hand,
+[D]Put your finger in the wedding band
+[G]Daddy gave you a piece of land
+[D]Made ourselves the best of plans
+
+[A]Forty years go by with someone [G]layin' in your [D]bed
+[A]Forty years of things you say you
+[G]wish you'd never [D]said
+[A]How hard would it have been to say some
+[G]kinder words in[D]stead,
+I [G]wonder as I stare out at the [A]sky all turnin' red...
+{colb}
+
+[G]I've had some time to think a[D]bout it
+[G]and watch the sun sink like a [D]stone
+[G]I've had some time to think [Bm]about you
+on the [A]long ride [D]home
+
+[G]Headlights searchin' down the [D]driveway
+[G]Our house is dark as it can [A]be.
+[G]I go inside and all is [Bm]silent,
+and seems as [A]empty as the inside of me.
+
+[G]I've had some time to think a[D]bout it
+[G]and watch the sun sink like a [D]stone
+[G]I've had some time to think [Bm]about you
+on the [A]long...
+on the [G]long...
+on the [A]long...
+on the [G]lo-oo-oo-ong ride [D]home.

--- a/songs/man_of_constant_sorrow.cho
+++ b/songs/man_of_constant_sorrow.cho
@@ -1,0 +1,41 @@
+
+{t:Man of Constant Sorrow}
+{st:Richard Burnett, 1913}
+{st:lyrics slightly different from Dylans and Burnetts.}
+ 
+Intro:
+[F] [Bb] [C] [Bb] [F]
+
+([Bb]Constant [C]sorrow [Bb]through his [F]days)
+
+[F]I     am a man    of constant [Bb]sorrow
+I've seen [C]trouble [(Bb)]all my [F]days
+[F]I'll  bid farewell    to old Ken[Bb]tucky 
+The place where [C]I     was [(Bb)]born and [F]raised
+(The [Bb]place where [C]he    was [Bb]born and [F]raised)
+
+[F]For six long years I've been in [Bb]trouble 
+No pleasure [C]here on [(Bb)]earth I [F]found 
+[F]For in this world I'm bound to [Bb]ramble 
+I have no [C]friends to [(Bb)]help me [F]down 
+(He [Bb]has no [C]friends to [Bb]help him [F]down)
+
+{colb}
+[F]It's fare thee well my old true [Bb]lover 
+I [(Bb)]never [C]expect to see [(Bb)]you [F]again 
+[F]For I'm bound to ride that northern [Bb]railroad 
+Perhaps I'll [C]die [(Bb)]upon this [F]train 
+(Per[Bb]haps he'll [C]die [Bb]upon this [F]train)
+ 
+[F]You can bury me in sunny [Bb]valley 
+For [(Bb)]many [C]years where I [(Bb)]may [F]lay 
+[F]And you may learn to love [Bb]another 
+While I am [C]sleepin' in [(Bb)]my [F]grave 
+(While [Bb]he is [C]sleepin' in [Bb]his [F]grave) 
+
+[F]Maybe your friends think I'm just a [Bb]stranger 
+My [(Bb)]face you [C]never will [(Bb)]see no [F]more 
+[F]But there is one promise that is [Bb]given 
+I'll meet you [C]on God's [(Bb)]golden [F]shore 
+(He'll [Bb]meet you [C]on God's [Bb]golden [F]shore)
+

--- a/songs/mary_janes_last_dance.cho
+++ b/songs/mary_janes_last_dance.cho
@@ -1,0 +1,63 @@
+{t:Mary Jane's Last Dance}
+{st:Tom Petty}
+
+Intro:
+4x [Am] [G] [D] [Am]
+
+[Am]She grew up in an [G]Indiana town
+Had a [D]good lookin' mama who [Am]never was around
+But she [Am]grew up tall and she [G]grew up right
+With them [D]Indiana boys on an [Am]Indiana night.
+
+[Am]harmonica [G] [D] wee-oo [Am]
+[Am]harmonica [G] [D] wee-oo [Am]
+
+[Am]Well she moved down here at the [G]age of 18
+She [D]blew the boys away, was [Am]more than they had seen
+[Am]I was introduced and we [G]both started groovin'
+She [D]said, "I dig you baby, but I [Am]got to keep movin' -
+[Am]... on[G], [D] keep movin' on" [Am]
+[Am] [G] [D] [Am]
+
+{comment:Chorus:}
+
+{soc}
+[Em7]Last dance with Mary Jane,
+[Em7]one more time to kill the pa[A]in.
+[Em7]I feel summer creepin' in, and I'm
+[Em7]tired of this town aga[A]in.[G]
+{eoc}
+
+[Am]harmonica [G] [D] wee-oo [Am]
+[Am]harmonica [G] [D] wee-oo [Am]
+
+{colb}
+Well, [Am]I don't know but [G]I've been told
+you [D]never slow down, you [Am]never grow old.
+[Am]Tired of screwin' up, [G]tired of goin' down,
+[D]tired of myself, [G]tired of this town.
+[Am]Oh, my my, [G]oh, hell yes.
+[D]Honey put on that [Am]party dress.
+[Am]Buy me a drink, [G]sing me a song,
+[D]take me as I come 'cause I [Am]can't stay long.
+
+Chorus
+
+Guitar solo:
+4x [Am] [G] [D] [Am]
+
+There's [Am]pigeons down on [G]market square,
+[D]she's standin' in her [Am]underwear
+[Am]lookin' down from her [G]hotel room,
+and [D]nightfall will be [Am]comin' soon.
+[Am]Oh, my my, [G]oh, hell yes,
+You [D]got to put on that [Am]party dress.
+It was [Am]too cold to cry when I [G]woke up alone.
+I [D]hit my last number, I [Am]walked to the road.
+
+Chorus
+
+[Am](harmonica) [G] [D] wee-oo [Am] (2x)
+[Am](harmonica and guitar) [G] [D] wee-oo [Am] (2x)
+[Am](guitar only) [G] [D] [Am] (4x, then fade out)
+

--- a/songs/more_than_words.cho
+++ b/songs/more_than_words.cho
@@ -1,0 +1,50 @@
+
+{t:More Than Words}
+{st:Extreme}
+
+{define:Fmaj7 1 0 3 2 1 x}
+
+{comment:Normally tuned down a half step (one fret)}
+
+/ G - - - / Cadd9 - - - / Am7 - - - / C - D Dsus4 / (x2)
+
+[G] Sayin' I [Cadd9]love you is [Am7]not the words I [C]want to [D]hear [Dsus4]from
+[G] you.  It's not that I [Cadd9]want you [Am7]not to say but [C]if you [D]on[Dsus4]ly
+[Em] knew how [Am7]easy [D7]it would be to [G]show me [D]how [Dadd2]you [Em]feel.
+More than [Am7]words is [D7]all you have to [G7]do to make it [C]real
+then you [Cm]wouldn't have to [G]say that you [Em7]love me
+cause [Am7]I'd al[D7]ready [G]know.
+
+What would you [D]do if my [Em]heart was [Bm]torn in [C]two
+More than words to show [G]you [Am7]feel that your [D7]love for me is [G]real
+What would you [D]say if I [Em]took those [Bm]words [C]away
+then you couldn't make [G]things [Am7]new
+just by [D7]saying I love [G]you
+
+[G] [Cadd9]La de da la de [Am7]da de da de dye dye [C]da
+[D]More [Dsus4]than [G]words
+[Cadd9] La de da [Am7] [D7] [G]
+
+Now that I've [Cadd9]tried to [Am7]talk to you and [C]make you [D]un[Dsus4]der[G]stand
+All you [Cadd9]have to do is [Am7]close your eyes and [C]just reach [D]out [Dsus4]your [Em]hand
+and [Am7]touch me.
+[D7]Hold me close don't [G]ever [D]let me [Em]go
+More than [Am7]words is [D7]all you have to [G7]do to make it [C]real
+then you [Cm]wouldn't have to [G]say that you [Em7]love me
+cause [Am7]I'd al[D7]ready [G]know.
+
+What would you [D]do if my [Em]heart was [Bm]torn in [C]two
+More than words to show [G]you [Am7]feel that your [D7]love for me is [G]real
+What would you [D]say if I [Em]took those [Bm]words [C]away
+then you couldn't make [G]things [Am7]new
+just by [D7]saying I love [G]you
+
+[G] [Cadd9]La de da la de [Am7]da de da de dye dye [C]da
+[D]More [Dsus4]than [G]words
+[G] [Cadd9]La de da la de [Am7]da de da de dye dye [C]da
+[D]More [Dsus4]than [G]words
+[G] [Cadd9]La de da la de [Am7]da de da de dye dye [C]da
+[D]More [Dsus4]than [G]words
+[G] [Cadd9]La de da la de [Am7]da de da de dye dye [C]da
+[D]More [Dsus4]than [G]words
+

--- a/songs/my_sweet_annette.cho
+++ b/songs/my_sweet_annette.cho
@@ -1,0 +1,55 @@
+{title:My Sweet Annette}
+{subtitle:Drive-By Truckers}
+
+{comment:Tuned down a whole step (2 frets)}
+
+Intro:
+
+[Am] [C] [G] [D]
+[Am] [C] [G] [D]
+[Am] [C] [G] [D]
+
+[Am]Me and my Annette, we was as [C]fond as we could be.
+[G]We was set to marry in Oc[D]tober '33.
+I [Am]set my sights to courtin' her, as [C]fine as she could be.
+I [G]never ever noticed her [D]best friend Marilee.
+
+
+Took a [Am]job at the saw mill and I [C]bought my girl a ring,
+Had a [G]pre-wedding party, close [D]friends and family.
+[Am]Everything was fine, eatin' [C]homemade ice cream...
+I [C]swear I never noticed maid of [D]honor, Marilee 
+
+
+Chorus:
+[Am]My sweet Annette [C]was left standing at the [G]altar  [D]
+[Am]My sweet Annette [C]was left standing at the [G]altar  [D]
+
+Violin solo:
+[Am] [C] [G] [D]
+[Am] [C] [G] [D]
+
+[Am]Marilee was taken ill, it was [C]several miles from home.
+Back [G]then it wasn't fittin' for a [D]girl to leave alone.
+[Am]sweet Annette, she asked me to [C]walk her to the door,
+As [G]innocent as children back be[D]fore the war.
+
+{colb}
+
+Chorus 
+
+[Am]Lord have mercy for [C]what we done.
+[G]Lord have mercy when two [D]people get alone.
+[Am]Neither one of us had done any[C]thing like that, you see.
+By the [G]next sunset, I had el[Em]oped with Marilee, 
+By the [G]next sunset, I had el[Em]oped with Marilee, 
+By the [G]next sunset, I had el[Em]oped with Marilee, 
+
+Guitar solo with Violin:
+[Am] [C] [G] [D]
+[Am] [C] [G] [D]
+[Am] [C] [G] [D]
+[Am] [C] [G] [D]
+
+[Am]My sweet Annette [C]was left standing at the [G]altar...
+

--- a/songs/my_sweet_annette.transposed.cho
+++ b/songs/my_sweet_annette.transposed.cho
@@ -1,0 +1,47 @@
+{title:My Sweet Annette}
+{subtitle:Drive-By Truckers}
+
+[Gm] (intro) [B] [F] [C]
+
+[Gm]Me and my Annette, we was as [B]fond as we could be.
+[F]We was set to marry in Oc[C]tober '33.
+I [Gm]set my sights to courtin' her, as [B]fine as she could be.
+I [F]never ever noticed her [C]best friend Marilee.
+
+
+Took a [Gm]job at the saw mill and I [B]bought my girl a ring,
+Had a [F]pre-wedding party, close [C]friends and family.
+[Gm]Everything was fine, eatin' [B]homemade ice cream...
+I [F]swear I never noticed maid of [C]honor, Marilee 
+
+
+Chorus:
+[Gm]My sweet Annette [B]was left standing at the [F]altar  [C]
+[Gm]My sweet Annette [B]was left standing at the [F]altar  [C]
+
+[Gm] (Violin Solo) [B] [F] [C]
+[Gm] [B] [F] [C]
+
+{colb}
+
+[Gm]Marilee was taken ill, it was [B]several miles from home.
+Back [F]then it wasn't fittin' for a [C]girl to leave alone.
+[Gm]sweet Annette, she asked me to [B]walk her to the door,
+As [F]innocent as children back be[C]fore the war.
+
+Chorus 
+
+[Am]Lord have mercy for [B]what we done.
+[F]Lord have mercy when two [C]people get alone.
+[Gm]Neither one of us had done any[B]thing like that, you see.
+By the [F]next sunset, I had el[Dm]oped with Marilee, 
+By the [F]next sunset, I had el[Dm]oped with Marilee, 
+By the [F]next sunset, I had el[Dm]oped with Marilee, 
+
+[Gm] (Guitar solo with Violin) [B] [F] [C]
+[Gm] [B] [F] [C]
+[Gm] [B] [F] [C]
+[Gm] [B] [F] [C]
+
+[Gm]My sweet Annette [B]was left standing at the [F]altar...
+

--- a/songs/need_you_now.cho
+++ b/songs/need_you_now.cho
@@ -1,0 +1,45 @@
+{title:Need You Now}
+{subtitle:Lady Antebellum}
+ 
+{comment:Capo 4}
+
+{define:Fmaj7 1 0 3 2 1 x}
+
+{comment:intro: Fmaj7 Am riff on piano backed by quiet guitar}
+
+Fmaj7 Am
+
+[Fmaj7]Picture perfect memories scattered all around the fl[Am]oor.
+[Fmaj7]Reachin' for the phone 'cause I can't fight it any[Am]more.
+And I [Fmaj7]wonder if I ever cross your [Am]mind.
+For me it [Fmaj7]happens all the time...
+
+It's a [C]quarter after one, I'm all alone and I [Em]need you now.
+[C]Said I wouldn't call but I lost all control and I [Em]need you now.
+And I [F]don't know how I can do without,
+I just need you [Fmaj7]now...  [Am]
+
+[Fmaj7]Another shot of whisky, can't stop looking at the [Am]door.
+[Fmaj7]Wishin' you'd come sweeping in the way you did be[Am]fore
+And I [Fmaj7]wonder if I ever cross your [Am]mind...
+For me it [Fmaj7]happens all the time.
+
+It's a [C]quarter after one, I'm a little drunk and I [Em]need you now.
+[C]Said I wouldn't call but I lost all control and I [Em]need you now.
+And I [F]don't know how I can do without,
+I just need you [Am]now...  [G] [C]
+[F] [G] Whoa-[Am]oh [G] [C]
+
+[F] [G] Yes, I'd [Fmaj7]rather hurt than feel nothin' at [Am]all[G]...
+{colb}
+
+It's a [C]quarter after one, I'm all alone and I [Em]need you now.
+I [C]said I wouldn't call but I'm a little drunk and I [Em]need you now.
+And I [F]don't know how I can do without,
+I just need you [C]now... [Em]
+I just need you [C]now... [Em]
+[C] [Em]Oh, baby I need you
+[C]Now [Em]
+
+{comment:outro: C Em riff on piano backed by quiet guitar}
+

--- a/songs/no_rain.cho
+++ b/songs/no_rain.cho
@@ -1,0 +1,37 @@
+{title:No Rain}
+{subtitle:Blind Melon}
+
+[E]All I can say is that my [D]life is pretty plain
+I [A]like watchin' the puddles [G]ather [E]rain [E7]
+And [E]all I can do is just [D]pour some tea for two
+and [A]speak my point of view but [G]it's not [E]sane, [E7]it's not sane.
+
+{comment:Chorus:}
+
+{soc}
+[E] I just want [D] someone to [E]say to me, [D]oh,
+[E] I'll always [D]be there when you [E]wake, [D] yeah...
+[E] Ya know I'd like to [D]keep my cheeks [E]dry tod[D]ay
+[E] So stay with [D]me and I'll have it [E]made. [D]
+{eoc}
+
+[E]I don't understand why I [D]sleep all day
+and I [A]start to complain when [G]there's [E]no rain [E7]
+And [E]all I can do is read a [D]book to stay awake
+It [A]rips my life away, but it's a [G]great [E] escape [E7]
+escape, escape, escape
+
+{comment:guitar solo}
+
+[E] [D] [E] [D]
+
+[E]All I can say is that my [D]life is pretty plain
+You don't [A]like my point of view, you [G]think that [G]I'm [E]insane [E7]
+It's not sane, it's not sane
+
+{comment:Chorus}
+
+{comment:repeat "I'll have it made" and fade out}
+
+[E] [D] [...]
+ 

--- a/songs/norwegian_wood.cho
+++ b/songs/norwegian_wood.cho
@@ -1,0 +1,19 @@
+
+{t:Norwegian Wood}
+{st:Beatles}
+
+[D]I once had a [D(C#bass)]girl or should I [D]say [C]she once [G]had [D]me
+[D]She showed me her [D(C#bass)]room isn't it [D]good [C]Norweg[G]ian [D]wood
+
+She [Dm]asked me to stay and she told me to sit any[G]where
+But [Dm]I looked around and I noticed there wasn't a [Em]chair[A]
+
+[D]I sat on a [D(C#bass)]rug biding my [D]time [C]drinking [G]her [D]wine
+[D]We talked until [D(C#bass)]two and then she [D]said [C]it's time [G]for [D]bed
+
+She [Dm]told me she worked in the morning and started to [G]laugh
+I [Dm]told her I didn't and crawled off to sleep in the [Em]bath [A]
+
+[D]And when I a[D(C#bass)]woke I was a[D]lone [C]this bird [G]had [D]flown
+[D]So I lit a [D(C#bass)]fire isn't it [D]good [C]Norwe[G]gian [D]wood
+

--- a/songs/one.cho
+++ b/songs/one.cho
@@ -1,0 +1,66 @@
+{even}
+{t:One}
+{st:U2}
+
+Slow Strum:
+{sot}
+              D   D U   U D U
+(folk strum)  1 + 2 + 3 + 4 +
+{eot}
+Fast Strum:
+{sot}
+              D   D DU UD D DU
+              1 + 2 + 3 + 4 +
+{eot}
+
+{define: Dsus2 x x 0 2 3 0}
+{define: Fmaj7 1 x 3 2 1 0}
+
+Intro:  [Am] [Dsus2] [Fmaj7] [G]
+
+[Am]  Is it getting bett[Dsus2]er,            [Fmaj7]  or do you feel the [G]same?
+[Am]  Will it make it e[Dsus2]asier on you now     [Fmaj7]  You've got someone to [G]blame? 
+
+You say,[C] one love,[Am] one life,[Fmaj7] when it's one need[C] in the night
+
+[C] One love,[Am] we get to share it, it[Fmaj7] leaves you baby if you[C] don't care for it
+
+ 
+/ Am - - - / Dsus2 - - - / Fmaj7 - - - / G - - - / 
+
+[Am]  Did I disap[Dsus2]point you,[Fmaj7] or leave a bad taste in your [G]mouth?
+
+[Am]  You act like you never [Dsus2]had love,  [Fmaj7]  and you want me to go with[G]out. 
+
+Well it's[C] too late[Am] tonight[Fmaj7]  to drag the past out in[C]to the light
+
+We're [C]one, but we're [Am]not the same, we get to [Fmaj7]carry each other,
+
+[C]carry each other.  One....
+ 
+/ Am - - - / Dsus2 - - - / Fmaj7 - - - / G - - - / 
+
+# {colb}
+[Am]   Have you come here for for[Dsus2]giveness? [Fmaj7]  Have you come to raise the [G]dead?
+[Am]   Have you come here to play [Dsus2]Jesus          [Fmaj7]  to the lepers in your [G]head?
+[C] Did I ask too much?[Am]  More than a lot? [Fmaj7]  You gave me nothing, now it's[C] all I got
+
+We're [C]one but we're [Am]not the same, well we [Fmaj7] hurt each other
+
+Then we [C]do it again, you say
+
+[C]  Love is a temple, [Am]love a higher law.[C]  Love is a temple, [Am]love a higher law.
+
+You [C]ask me to enter, but [G]then you make me crawl
+
+And I[G] can't be holding on[F] to what you got,[F] when all you got is hurt
+[C] One love,[Am]  one blood, [Fmaj7]  one life, you got to [C]do what you should
+
+[C] One life,[Am] with each other,[Fmaj7] sisters,[C] brothers
+
+[C] One life, but we're[Am] not the same, we get [Fmaj7]to carry each other,
+
+Car[C]ry each other, one....
+
+/ C - - - / Am - - - / Fmaj7 - - - / C - - - /  x5, hold last C
+

--- a/songs/patience.cho
+++ b/songs/patience.cho
@@ -1,0 +1,73 @@
+{t:Patience}
+{st:Guns N'Roses}
+
+#
+#From: schubert@avalon.physik.unizh.ch (Schubert Alex)
+#Subject: RE: Request G'n'R   Patience.crd
+#Date: 4 Sep 92 11:22:30 GMT
+#
+#lyric correction by
+#Date:   Mon, 27 Nov 1995 22:34:01 -1000
+#From: Peruzan Dadbeh 
+#
+#
+#PATIENCE (by Guns n Roses)
+#===========================
+#
+Intro:
+[C]  [G]  [A]  [D]     [C]  [G]  [A]  [D]
+[C]  [G]  [C]  [Em]     [C]  [G]  [D]  [D]
+[C]Shed a tear cause I'm missing you
+I'm [G]still allright to smile
+[A]Girl I think about you every [D]day now
+[C]Was a time when I wasn't sure
+But you [G]set my mind at ease
+[A]There is no doubt, you're in my [D]heart now
+[C]Said woman t[G]ake it slow
+It will [C]work itself out [Em]fine
+[C]All we need is [G]just a little pa[D]tience
+[C]Said sugar m[G]ake it slow and
+It [C]comes together [Em]fine
+[C]All we need is [G]just a little pa[D]tience
+[C]Sit here on the stairs
+Cause I'd [G]rather be alone
+If I [A]can't have you right now,
+I'll [D]wait dear.
+[C]Sometimes I get so candescent
+But I [G]can't speed up the time
+[A]You know love, there's one more thing
+To con[D]sider
+{colb}
+[C]Said woman [G]take it slow
+And [C]things will be just [Em]fine
+[C]You and I just [G]use a little pa[D]tience
+[C]Said sugar [G]take the time
+Cause the [C]lights are shining [Em]bright
+[C]You and I got [G]what it takes to [D]make it
+[D]We don't fake it
+[D]Ahh and never break it
+[D]Cause I can't take it
+
+Solo
+
+[G]A lit[C]tle patience
+[G]Mmmm Y[C]eah
+[G]I've been walking the streets tonight
+[C]Just trying to get it right
+[G]It's hard to see with so many around
+Ya [C]know I don't like being stuck in a crowd
+And the [G]streets don't change but maybe the name
+[C]I ain't got time for the game
+Cause I [G]need you
+Yeah Yeah cause I [C]need you
+Uh I n[G]eed you
+Woh I [D]need you
+Uhh this t[G]ime [C] [G]
+
+#Well, the lyrics are from a friend, who tried to figure them out. I don't guarantee they're absolutely
+#correct, but I guess they can give you a very good idea of the song. (Any corrections?)
+#Thus I could post a corrected version.
+#Did anyone figure out  the  Intro   and Solo ?
+#Your posting would be appreciated!
+#Have fun playing it!!!!!
+#           Alex  (almost a real Schubert  :)

--- a/songs/peaceful_easy_feeling.cho
+++ b/songs/peaceful_easy_feeling.cho
@@ -1,0 +1,55 @@
+{t:Peaceful Easy Feeling}
+{st:The Eagles}
+
+{comment:Capo 2}
+
+Intro:
+[D] [Dsus] [D] [Dsus]
+
+[D]I like the [G]way your sparklin' [D]earrings [G]lay
+[D]against your [G]skin so [A]brown.
+[D]And I wanna [G]sleep with you in the [D]desert to[G]night
+[D] with a billion [G]stars all [A]around.
+
+{comment:Chorus:}
+
+{soc}
+'Cause I got a [G]peaceful easy fe[D]elin'
+[G]and I know you won't let me [Em7]down,
+[A] 'cause I'm [D]al - [Em7]ready [G]standin'
+[Asus4] on the [D]ground.
+{eoc}
+
+[D]And I found [G]out a long [D]time a[G]go
+[D]What a woman can [G]do to your [A]soul.
+[D]Oh, but [G]she can't take you [D]any[G]way
+[D]you don't already [G]know how to [A]go.
+
+{comment:Chorus}
+
+{colb}
+
+[D] [G] [D] [G]
+[D] [G] [A] [A]
+[D] [G] [D] [G]
+[D] [G] [A] [A]
+[G] [D]
+[G] [Em7]
+[A] [D] [Em7] [G]
+[Asus4] [D]
+
+[D] I got this [G]feelin' I may [D]know [G]you
+[D]as a [G]lover and a [A]friend, but
+[D]this voice keeps [G]whispering [D]in my other [G]ear, tells me
+[D]I may never [G]see you [A]again.
+
+{soc}
+'Cause I get a [G]peaceful easy fe[D]elin'
+[G]and I know you won't let me [Em7]do[A]wn,
+'cause I'm [D]al - [Em7]ready [G]standin',
+[A]'cause I'm [D]al - [Em7]ready [G]standin',
+[A]yes I'm [D]al - [Em7]ready [G]standin',
+[Asus4] on the [D]ground.
+{eoc}
+
+

--- a/songs/ring_of_fire.cho
+++ b/songs/ring_of_fire.cho
@@ -1,0 +1,34 @@
+
+{t:Ring of Fire}
+{st:Johnny Cash}
+
+#
+#Intro: G  C  G  C
+#
+[G]Love is a [C]burning [G]thing
+[G]and it makes a [C]firery [G]ring
+[G]Bound by [C]wild [G]desire
+I [G]fell into a [C]ring of [G]fire
+
+Chorus:
+I [D]fell into a [C]burning ring of [G]fire
+I went [D]down, down, down
+and the [C]flames went [G]higher
+and it [G]burns, burns, burns
+The [C]ring of [G]fire
+The [C]ring of [G]fire
+
+Repeat intro twice.
+Repeat chorus.
+
+{colb}
+[G]The taste of [C]love is [G]sweet
+when [G]hearts like [C]ours [G]meet
+I [G]fell for you [C]like a [G]child
+[G]Ohh, but the [C]fire went [G]wild
+
+Repeat chorus 2x's
+
+And it burns, burns, burns
+The [C]ring of [G]fire
+The [G]ring of [G]fire

--- a/songs/salty_south.cho
+++ b/songs/salty_south.cho
@@ -1,0 +1,67 @@
+
+{t:Salty South}
+{st:Indigo Girls}
+
+{comment: Intro G D Em C D }
+
+[G]Mister pull up a chair
+[D]I've got time for tears
+[Em]So tell me all the stories that you never [C]did. [D]
+
+[G]Of the salty south,
+[D]the Seminoles held out,
+[Em]while Geronimo died in a lonely [C]jail. [D]
+
+[C]A thousand tides,
+[G]A thousand waves,
+[Bm]Takin' it all aw[C]ay. [D]  
+
+[G]It'll come back in, but
+[D]We'll be gone by then, and it's a
+[Em]miracle we ever learned to [C]live. [D]
+
+[G]Drained that land
+[D]For a better plan
+[Em]Sugar cane and the civil [C]man. [D]
+
+And now they're
+[G]ringing dead them pines
+[D]Planted in that time
+[Em]They gonna keep on killing 'til they get it [C]right. [D]
+
+{colb}
+
+[C]A thousand tides,
+[G]A thousand waves,
+[Bm]Takin' it all aw[C]ay. [D]  
+
+[G]It'll come back in, but
+[D]We'll be gone by then, and it's a
+[Em]miracle we ever learned to [C]live. [D]
+
+{comment: harmonica solo G Em C Am D}
+{comment: harmonica solo G Em C Am D}
+
+{comment: G extra measure }
+
+(softer) [G]I remember the wind
+[D]As it was settlin', and every
+su[Em]n goin' down was a picture [C] then. [D]
+
+[G]But we look back in frames
+[D]They all look the same
+[Em]There's no sense of time, no sense of [C] pain. [D]
+
+(louder) [C]A thousand tides,
+[G]A thousand waves,
+[Bm]Takin' it all aw[C]ay. [D]  
+
+[G]And it'll come back in, but
+[D]We'll be gone by then, and it's a
+[Em]miracle we ever learned to [C]give. [D]
+
+{comment: banjo solo G Em C Am D}
+{comment: banjo solo G Em C Am D}
+
+{comment: end on G}
+

--- a/songs/service_and_repair.cho
+++ b/songs/service_and_repair.cho
@@ -1,0 +1,59 @@
+{t:Service and Repair}
+{st:Calexico}
+#Album: Hot Rail
+
+#E7sus4:
+#e:-0-
+#B:-0-
+#G:-2-
+#D:-0-
+#A:-2-
+#e:-0-
+
+[Am]On the [F]outskirts [E7sus4] of ex[Am]pansion
+[Am]Looking [F]out from Blue[E7sus4]print Peak [E7]
+[Am]The flow is [F]flooding [E7sus4] of urban [Am]settlers
+[Am]Panning [G]through [F]rivers [E7sus4]running [Am]dry
+
+[F]Numbers roll on [C]in,     [G]smiling a lottery [Am]grin
+As [F]sadness blurs the [C]eye
+It's just a matter of [Dm]time [Bb] in the moving [C]on
+It's just a matter of [Dm]time [Bb] before the moving [C]on
+Doesn't take much [Dm]time for [Bb]plans to go [C]wrong
+Chase another [Dm]ghost of a [Bb]chance
+ 
+[Am]In the [F]shadows of [E7sus4] chainstore [Am]ghost towns
+Where no one [F]walks the  streets [Esus4]at         night [E7]
+[Am]The silent [F]nation [E7sus4]hooked on medi[Am]cation
+Am]Stares [G]into a [F]blue [E7sus4]flickering [Am]light
+
+The [F]young drift off a[C]lone and the [G]old waste a[Am]way
+And the [F]prospects keep looking [C]up
+But the line is getting [Dm]long [Bb]on the lost high[C]way
+
+{colb}
+The line's getting [Dm]longer [Bb]on the lost high[C]way
+Doesn't take much [Dm]time [Bb]for plans to go [C]astray
+Chase another [Dm]ghost of a [Bb]chance
+
+
+(instrumental)
+like verse
+
+They [F]say deep down [C]inside
+Lie [G]properties of a healing [Am]kind
+If [F]so, better come around[C] soon
+
+Do a little bit of [Dm]service [Bb]and re[C]pair
+Do a little bit of [Dm]service [Bb]and re[C]pair
+Do a little more  [Dm]service [Bb]and re[C]pair
+Doesn't take much [Dm]time for [E7]plans to [F]change
+
+[Fm]And offer up [C]another [G]chance
+For a [C]little bit more  [Dm]service [Bb]and re[C]pair 
+A little bit more  [Dm]service [Bb]and [C]repair
+Doesn't take much [Dm]time for [E7]plans to [F]change
+[Fm]And offer up [C]another [G]chance
+At [Fm]sowing the [C]dreams that [G]suited for
+[F]both soul and [C]soil
+

--- a/songs/soul_meets_body.cho
+++ b/songs/soul_meets_body.cho
@@ -1,0 +1,62 @@
+{title:Soul Meets Body}
+{subtitle:Death Cab For Cutie}
+
+{comment:Capo 5}
+
+[Am] [C]
+[Am] [C]
+
+[Am]I want to live where [C]soul meets body.
+[Am]And let the sun wrap its [C]arms around me and
+[Am]bathe my skin in water [C]cool and cleansing and
+[G]feel, feel what its like to be [Am]new.
+
+[Am]Cause in my head, there's a [C]greyhound station.
+[Am]Where I send my thoughts to [C]far off destinations
+[Am]So they may have a chance of [C]finding a place
+where they're [G]far more suited than here
+
+[Am]ba da ba [C]da ba [G]bada ba da
+[Am]ba ba ba[C]da ba ba [G]ba bada
+[Am]ba ba ba[C]da ba [G]bada bada
+[Am]ba [C] [G]
+
+[Am] [C] [Am] [C]
+
+[Am]I cannot guess what [C]we'll discover
+[Am]We turn the dirt with our [C]arms cupped like shovels
+but I [Am]know our filthy hands can [C]wash one another's
+and [G]not one speck will remain
+
+{colb}
+
+{comment:Chorus:}
+
+{soc}
+[Am]I do be[C]lieve it's [G]true that there are
+[Am]roads left in [C]both of our [G]shoes but if the
+[Am]silence takes [C]you then I [G]hope it takes me too
+[Am] [C] [G]
+
+So [Am]brown eyes I [C]hold you [G]near
+'cause you're the [Am]only song I [C]want to [G]hear,
+a melo[Am]dy softly [C]soaring [G]through my atmosphere
+[Am] [C] [G]
+{eoc}
+
+Where soul[Am x5] meets [Am x4]body [C] [C]
+[Am x5] [...] [Am x4]
+Where soul[Am x5] meets [Am x4]body [C]
+Where [G]soul meets body
+
+{comment:Chorus}
+
+[Am]A melody softly [C]soaring [G]through my atmosphere
+[Am] [C] [G]
+[Am]A melody softly [C]soaring [G]through my atmosphere
+[Am] [C] [G]
+[Am]A melody softly [C]soaring [G]through my atmosphere
+[Am] [C] [G]
+
+{comment:hold on last G}
+

--- a/songs/southern_cross.cho
+++ b/songs/southern_cross.cho
@@ -1,0 +1,57 @@
+
+{even}
+{title:Southern Cross}
+{subtitle:Stephen Stills, Richard Curtis, and Michael Curtis}
+
+{comment:Strumming rhythm is key}
+
+The intro is :  A  G  D  -  A G D A
+
+[A]Got out of town on a [G]boat goin' to southern is[D]lands
+Sailing a [A]reach be[G]fore a following [D]sea.  [A]
+[A]She was making for the [G]trades on the [D]outside,
+and the [A]downhill run [G]to Pape-ete [D]Bay. [A]
+
+Off the [A]wind on this [G]heading lie the Mar[D]quesas
+We got eig[A]hty feet of [G]waterline [D]nicely [Bm]making [A]way
+In a [A]noisy bar in [G]Avalon, I tried to [D]call you
+But on the [A]midnight watch I [G]realized why [D]twice you [Bm]ran a[A]way.
+
+{comment:Chorus:}
+
+{soc}
+[G]Think about [D]how many times I[G] have [A]fallen
+[G]Spirits are [D]usin' me; [G]larger voices [A]callin'
+[G]What heaven brought [D]you and me [G]cannot be forg[A]otten.
+
+I have been [D]around[G] the [A]world,
+[D]looking for that wo[G]man-[A]girl
+who [D]knows love [G]can end[A]ure.
+And you know it w[A]ill[G].  [D]
+[A] [G] [D] [A]
+{eoc}
+
+
+[A]When you see the Southern [G]Cross for the [D]first time,
+You [A]understand now [G]why you came this [D]way.[A]
+'Cause the [A]truth you might be [G]running from is [D]so small.
+But it's as [A]big as the [G]promise, the [D]promise of a [Bm]comin' [A]day.
+
+So I'm [A]sailing for [G]tomorrow. My dreams are [D]a-dying.
+And my [A]love is an [G]anchor tied to you, [D]tied with a [Bm]silver [A]chain.
+I have my [A]ship, and [G]all her flags are [D]a-flying.
+She is [A]all that I have [G]left, and [D]music [Bm]is her [A]name.
+
+Think about...
+
+{comment:Chorus}
+
+So we [A]cheated and we [G]lied and we [D]tested.
+And we [A]never failed to [G]fail.  It was the [D]easiest thing to [A]do.
+You will sur[G]vive being [D]bested.
+Somebody [A]fine will [G]come along, make me [D]forget about [Bm]loving [A]you
+and the Southern [A]Cross. [G] [D]
+[A] [G] [D]
+
+{comment:hold last D}
+

--- a/songs/stuck_in_the_middle_with_you.cho
+++ b/songs/stuck_in_the_middle_with_you.cho
@@ -1,0 +1,59 @@
+{t:Stuck In The Middle With You}
+{st:Stealers Wheel}
+
+[D] (intro)
+
+[D]Well, I don't know why I came here tonight
+[D]I got the feelin' that something ain't right.
+I'm so [G7]scared in case I fall off my chair
+And I'm [D]wonderin' how I'll get down the stairs.
+[A]Clowns to the left of me, [C]jokers to the right[G],
+here I am [D]stuck in the middle with you.
+
+[D]Yes, I'm stuck in the middle with you
+[D]And I'm wonderin' what it is I should do.
+It's so [G7]hard to keep this smile from my face
+[D]Losing control, I'm all over the place.
+[A]Clowns to the left of me, [C]jokers to the right[G],
+here I am [D]stuck in the middle with you.
+
+Well you [G7]started out with nothin' and you're
+proud that you're a self-made man. [D]
+And your [G7]family all come crawlin',
+slap you on the back and say
+[D]Please... [A7?]Please...
+
+[D]
+[D]Tryin' to make some sense of it all,
+[D]but I can see it makes no sense at all.
+Is it cool[G7] to go to sleep on the floor,
+I don't [D]think I can take anymore.
+[A]Clowns to the left of me, [C]jokers to the right[G],
+here I am [D]stuck in the middle with you.
+{colb}
+
+[D] (solo)
+[D]
+[D]
+[G7]
+[D]
+[A]        [C]        [G]
+[D]
+
+Well you [G7]started out with nothin' and you're
+proud that you're a self-made man. [D]
+And your [G7]family all come crawlin',
+slap you on the back and say
+[D]Please... [A7?]Please...
+
+[D]Yeah, I don't know why I came here tonight
+[D]I got the feelin' that something ain't right.
+I'm so [G7]scared in case I fall off my chair
+And I'm [D]wonderin' how I'll get down the stairs.
+[A]Clowns to the left of me, [C]jokers to the right[G],
+here I am [D]stuck in the middle with you.
+Cause I'm [D]stuck in the middle with you.
+    [D]stuck in the middle with you.
+Here I am, [D]stuck in the middle with you.
+{comment: end on D}
+

--- a/songs/summer_of_69.cho
+++ b/songs/summer_of_69.cho
@@ -1,0 +1,59 @@
+
+{t:Summer of '69}
+{st:Bryan Adams}
+
+[D]I got my first real six-string,
+[A]boy at the five and dime.
+[D]Played it til my fingers bled.
+[A]Was the summer of '69.
+
+[D]Me and some guys from school,
+[A]had a band and we tried real hard.
+[D]Jimmy quit, Jody got married,
+[A]Shoulda known we'd never get far.
+
+[Bm]Oh, when I [A]look back now,
+[D]that summer seemed to [G]last forever.
+[Bm]And if I [A]had the choice,
+[D]yeah, I'd always [G]wanna be there.
+[Bm]Those were the [A]best days of my [D]life.
+[A] (hey)
+
+[D]Ain't no use in complainin'
+[A]when you got a job to do
+[D]Spent my evenings down at the drive-in,
+[A]and that's when I met you, yeah.
+
+[Bm]Standin' on your [A]momma's porch,
+[D]you told that you'd [G]wait forever.
+[Bm]Oh, the way you [A]held my hand,
+[D]I knew that it was [G]now or never.
+[Bm]Those were the [A]best days of my [D]life.
+[A]Oh, yeah, back in the summer of [D]'69.
+[A]Ohh! [D]
+
+{colb}
+[F]Man, we were [Bb]killin' time,
+we were [C]young and restless,
+we [Bb]needed to unwind.
+[F] I guess [Bb]nothing can last
+for[C]ever, forever, no.
+
+[D] Yeah! [A]
+[D] [A]
+
+[D]And now the times are changin'.
+[A]Look at everything that's come and gone.
+[D]Sometimes when I play that old six-string
+[A]I think about you, wonder what went wrong.
+
+[Bm]Standin' on your [A]momma's porch,
+[D]you told that it'd [G]last forever.
+[Bm]Oh, the way you [A]held my hand,
+[D]I knew that it was [G]now or never.
+[Bm]Those were the [A]best days of my [D]life.
+Oh, [A]yeah, back in the summer of [D]'69!
+Uh-[A]huh, it was the summer of [D]'69!
+Oh, [A]yeah, me and my baby in [D]'69!
+Ohh [A]Hey, it was the summer, the summer of [D]'69.
+

--- a/songs/sundown.cho
+++ b/songs/sundown.cho
@@ -1,0 +1,53 @@
+{title:Sundown}
+{subtitle:Gordon Lightfoot}
+ 
+{comment:Capo 2}
+
+{comment:intro: E.......E7 on upstroke (if you
+listen to the recording, you'll get the idea)}
+
+[E]I can see her lyin' back in her satin dress
+In a [B7]room where ya do what ya [E]don't confess
+
+Sundown ya [A]better take care
+If I [D]find you been creepin' 'round [E]my back stairs
+Sundown ya [A]better take care
+If I [D]find you been creepin' 'round [E]my back stairs
+
+[E]She's been lookin' like a queen in a sailor's dream
+And she [B7]don't always say what she [E]really means
+
+Sometimes I [A]think it's a shame
+When I [D]get feelin' better when I'm [E]feelin' no pain
+Sometimes I [A]think it's a shame
+When I [D]get feelin' better when I'm [E]feelin' no pain
+
+[E]I can picture every move that a man could make
+Getting [B7]lost in her lovin' is your [E]first mistake
+
+Sundown ya [A]better take care
+If I [D]find you been creepin' 'round [E]my back stairs
+Sometimes I [A]think it's a sin
+When I [D]feel like I'm winnin' when I'm [E]losin again
+
+{comment:acoustic guitar solo}
+
+[E]I can see her lookin' fast in her faded jeans
+She's a [B7]hard lovin' woman, got me [E]feelin' mean
+
+{colb}
+
+Sometimes I [A]think it's a shame
+When I [D]get feelin' better when I'm [E]feelin' no pain
+Sundown ya [A]better take care
+If I [D]find you been creepin' 'round [E]my back stairs
+Sundown ya [A]better take care
+If I [D]find you been creepin' 'round [E]my back stairs
+Sometimes I [A]think it's a sin
+When I [D]feel like I'm winnin' when I'm [E]losin' again
+
+{comment:acoustic guitar solo and fade out}
+
+# -------------------------------------------------- 
+# simescan (rick s.)
+

--- a/songs/sweet_child_of_mine.cho
+++ b/songs/sweet_child_of_mine.cho
@@ -1,0 +1,80 @@
+
+{t:Sweet Child Of Mine}
+{st:Guns N'Roses}
+{c:Intro}
+{sot}
+/ D - - - / - - - - / C - - - / - - - - /
+/ G - - - / - - - - / D - - - / - - - - /
+x 2, hold each chord 1st time
+{eot}
+#{sot}
+#  D chord                      C chord                  G chord 
+#e|-------------15----14----|T |-------------15----14----|T |-------------15----14----|T
+#B|----15-------------------|w |----15-------------------|w |----15-------------------|w 
+#G|-------14-12----14----14-|i |-------14-12----14----14-|i |-12----14-12----14----14-|i
+#D|-12----------------------|c |-14----------------------|c |-------------------------|c 
+#A|-------------------------|e |-------------------------|e |-------------------------|e
+#E|-------------------------|  |-------------------------|  |-------------------------|
+#{eot}
+
+[D]She's got a smile that it seems to me 
+Re[C]minds me of childhood memories
+Where [G]everything was as fresh as the bright blue [D]sky
+[D]Now and then when I see her face
+she [C]takes me away to that special place
+and if I [G]stared too long I'd probably break down and [D]cry
+
+Chorus:
+[A]Whoa-[C]oh sweet child of [D]mine
+[A]Whoa-[C]oh, oh oh [C]oh sweet love of [D]mine
+
+{comment:Solo 1:}
+{sot}
+/ D - - - / - - - - / C - - - / - - - - /
+/ G - - - / - - - - / D - - - / - - - - /
+{eot}
+
+[D]She's got eyes of the bluest sky
+as [C]if they thought of rain
+I [G]hate to look into those eyes and [D]see an ounce of pain
+Her [D]hair reminds me of a warm safe place
+where [C]as a child I'd hide
+and [G]pray for the thunder and the rain to [D]quietly pass me by.
+
+Chorus
+
+{c:Solo 2}
+{sot}
+/ D - - - / - - - - / C - - - / - - - - /
+/ G - - - / - - - - / D - - - / - - - - /
+x 2
+{eot}
+
+Chorus
+
+{colb}
+[A]Whoa, oh, oh, oh [C]Sweet child of mine, [D(2)]oooh, yeah!
+[A]Oooooooh, [C]Sweet love of mine[D((2, 8th note downstrokes))]
+
+{c:Solo 3}
+{sot}
+/ Em - - - / C - - - / B - - - / Am - - - / x3
+/ Em - - - / C - - - / B - - - / Am (8th note downstrokes) - - - / - - - - /
+/ Em - - - / G - - - / Am - - - / C - D G / x4
+{eot}
+
+w/breakdown strum:
+
+[Em]Where do we go, where [G] do we go now, [Am]where do we go? [/ C - D G /]
+[Em]Where do we go, where [G] do we go now, [Am]where do we go now? [/ C - D G /]
+[Em]Where do we go, [G]sweet child, where [D]do we go now? [/ C - D G /]
+[Em]Ay, Ay, Ay, Ay, Ay, [G]Ay, Ay, Ay, where [Am]do we go now,        [/ C - D G /]ah-ah-ah-ah
+[Em]Where do we gooo, [G]ahhh, where [Am]do we go now? [/ C - D G /]
+
+[Em]Where do we gooo[G]ooo, where [Am]do we go now? [/ C - D G /]
+[Em]Where do we go, [G]where [Am]do we go now?  [(w/Now Riff)]Now-now-now-now-now-now-
+
+  Em                 G               Am (hold)  C (hold)   D (hold)      Em (hold)
+
+[Em]now!  Sweet child, [G] sweet chi [Am (hold)] [C (hold)]            -                  [D (hold)] ld of [Em (hold)]mine
+

--- a/songs/take_it_easy.cho
+++ b/songs/take_it_easy.cho
@@ -1,0 +1,57 @@
+{t:Take It Easy}
+{st:Eagles}
+
+{comment:G D C}
+
+Well, I'm a-[G]runnin' down the road
+tryin' to loosen my load,
+I've got seven women [D]on my [C]mind.
+[G]Four that want to own me,
+[D]two that want to stone me,
+[C]one says she's a friend of [G]mine.
+
+Take it [Em]easy, take it easy
+Don't let the sound of your own wheels drive you crazy (ooo)
+Lighten up while you still can,
+don't even try to understand
+Just find a place to make your stand,
+and take it easy.
+
+Well I'm standin' on a corner in Winslow, Arizona.
+Such a fine sight to see.
+It's a girl my lord in a flat bed Ford,
+Slwoing' to take a look at me.
+
+Come on baby, don't say maybe.
+I've got to know if your sweet love is gonna save me.
+We may loose and we may win,
+but we will never be here again.
+So open up, I'm climbin' in.
+So take it easy.
+
+{comment: guitar solo}
+
+Well, I'm a-runnin' down the road
+tryin' to loosen my load,
+Got a world of trouble on my mind.
+Lookin for a lover who won't blow my cover,
+She's so hard to find.
+
+
+Take it easy, take it easy
+Don't let the sound of your own wheels make you crazy (ooo)
+Come on baby, don't say maybe.
+I've got to know if your sweet love is gonna sa-ave me.
+
+Ooo-ooo-ooh
+Ooo-ooo-ooh
+Ooo-ooo-ooh
+Ooo-ooo-ooh
+Ooo-ooo-ooh
+Ooo-ooo-ooh
+Ooo-ooo-ooh
+Ooo-ooo-ooh
+
+Oh, we got it easy.
+We oughta take it easy.
+

--- a/songs/too_late_for_love.cho
+++ b/songs/too_late_for_love.cho
@@ -1,0 +1,43 @@
+{t:Too Late for Love}
+{st:by Def Leppard}
+
+Intro: [Em] [C] [D] [Dsus4] [D] [C] [Em]
+{sot}
+-------------------------------------------
+-------------------------------------------
+-------------------------------------------
+---------2-----4--------5---4------2----2--
+-----2h3---3/5------3/5---5------3---3--2--
+-0--------------------------------------0--
+{eot}
+[Em]Somewhere in the distance, [C] I [D]hear the bell ring, [Dsus4]
+[D]Darkness settles on the [C]town, as the [Em]children start to sing
+And the [Em]lady across the street, [C] [D]she shuts out the night, [Dsus4]
+A [D]cast on thousands wait[C]ing, as [Em]she turns out the light, but it's
+[Em]Too late, [C] [D]too late, [Dsus4] [D]too late, [C]too [Em]late for love,
+[Em]Too late, [C] [D]too late, [Dsus4] [D]too late, [C]too [Em]late...
+
+[Em]London boys are gazing, [C] as [D]girls go hand in hand [Dsus4]
+with a [D]pocketful of inno[C]cence, the [Em]entrance is grand
+the [Em]queen of the dream, [C] [D]stand before them all [Dsus4]
+she [D]streaches out her hand [C] as the [Em]curtain starts to fall, but it's
+[Em]Too late, [C] [D]too late, [Dsus4] [D]too late, [C]too [Em]late for love,
+[Em]Too late, [C] [D]too late, [Dsus4] [D]too late, [C]too [Em]late!
+
+(Bridge) [Em]Woah oh oh [C]Oh oh oh oh (x2) 
+{sot}
+--------------------------------------------------
+--------------------------------------------------
+--------9-------7-----5------2-----4-----5-----5--
+-------10-------9-----7------3-----3-----3-----5v-
+-0-0-0-----0-0----0-0---0--0---0-0---0-0---0-0----
+--------------------------------------------------
+{eot}
+(solo) [Em] [C] [D] [Dsus4] [D] [C] [Em] [x2]
+
+[Em]Standing by the trap door, [C] a[D]ware of me and you [Dsus4]
+The [D]actor and the clown, [C]they're [Em]waiting for their cue
+And there's a [Em]lady over there, [C] she's [D]acting pretty cool [Dsus4]
+But [D]when it comes to playing [C]life, she [Em]always plays the fool, but it's
+[Em]Too late, [C] [D]too late, [Dsus4] [D]too late, [C]too [Em]late for love,
+[Em]Too late, [C] [D]too late, [Dsus4] [D]too late, [C]too [Em]late!

--- a/songs/walk_on_the_ocean.cho
+++ b/songs/walk_on_the_ocean.cho
@@ -1,0 +1,36 @@
+{t:Walk On The Ocean}
+{st:Toad The Wet Sprocket}
+
+{define: Asus4 0 0 2 2 3 0}
+{define: D/F# 2 0 0 2 3 2}
+
+{comment:Capo 4}
+
+VERSE 1:
+We spotted the [G]ocean[C] [G]     at the [A]head of the [Em]tra[C]il[G]
+But [A]where are we [G]going[C] [G],     we're [D]so far [A]aw[Asus4]ay    [A]
+Somebody [G]told[C] [G] me     that [A]this is the [Em]pla[C]ce[G]
+where [A]everything's [G]better[C] [G]     and [D]everything's [A]sa[Asus4]fe    [A]
+
+CHORUS:
+Walk on the [Em]Ocean[G]    Step on the [D]stone[A]
+Flesh becomes [Em]water[G]    Wood becomes [D]bone[A]
+
+VERSE 2:
+A half an hour [G]later[C] [G]    We [A]packed up our [Em]thi[C]ng[G]s
+We [A]said we'd send [G]letters[C] [G]    And [D]all of those [A]li[Asus4]ttle t[A]hings
+And they knew we were [G]lying [C] [G]    But they [A]smiled just the [Em]sam[C]e [G]
+It s[A]eemed they'd [G]already[C] [G]    For[D]gotten we [A]ca[Asus4]me    [A]
+
+CHORUS:(2X)
+
+BRIDGE:
+{comment:Play the chords of the chorus twice}
+
+VERSE 3:
+Now back at the [G]homestead[C] [G]    Where the [A]air makes you [Em]cho[D/F#]ke   [G]
+Where [A]people don't [G]know you[C] [G]    And [D]trust is a [A]jo[Asus4]ke    [A]
+Don't even have [G]pictures[C] [G]    Just [A]memories to [Em]hol[D/F#]d    [G]
+It grows [A]sweeter each [G]season[C] [G]    As we [D]slowly grow [A]old
+
+OPTIONAL CHORUS - repeat until fade

--- a/songs/wasted_on_the_way.cho
+++ b/songs/wasted_on_the_way.cho
@@ -1,0 +1,57 @@
+#----------------------------------PLEASE NOTE---------------------------------#
+#This file is the author's own work and represents their interpretation of the #
+#song. You may only use this file for private study, scholarship, or research. #
+#------------------------------------------------------------------------------##
+#Article 1085 of alt.guitar.tab:
+#From: bearce@hpcc01.corp.hp.com (Phil Bearce)
+#Date: Fri, 24 Jul 1992 16:16:43 GMT
+#Subject: MUSIC: Wasted On The Way - Graham Nash
+#Message-ID: <73410005@hpcc01.corp.hp.com>
+#Organization: the HP Corporate notes server
+#Path: nevada.edu!uunet!elroy.jpl.nasa.gov!sdd.hp.com!hpscdc!hplextra!hpcc05!hpcc01!bearce
+#Newsgroups: alt.guitar.tab
+#Lines: 72
+#
+#From phil@hpmsfpb.sj.hp.com Fri Jul 24 09:11 PDT 1992
+#
+{t:Wasted On The Way}
+{st:Graham Nash}
+
+# {define: Em/D x x 0 4 5 3}
+# {define: A/D x x 0 6 5 5}
+
+Intro: [D]  [Em/D]  [F#m7/D]  [D]  [A7/D]
+
+[D]  Look around me - I can [Bm]see my life before me
+Running [G]rings around the way[A] it used to [D]be  [Em/D] [D]
+[D]  I am older now - I have [Bm]more than what I wanted
+But I [G]wish that I had [A]started long before[G] I did[D]   [Em/D] [D]
+
+And there's[G]So much [A]time to make up [D]everywhere you turn   [Bm]
+[G]  Time we have [A]wasted on the way  [F#m]     [D7]
+[G]So much [A]water moving [D]underneath the br[Bm]idge
+Let the [G]water come and [A]carry us aw[G]ay   [D]
+
+{comment: Violin solo over verse chords}
+
+Oh, when [D]you were young, did you [Bm]question all the answers
+Did you e[G]nvy all the dan[A]cers who had [D]all [Em/D]the nerve[D]
+Look around you now - you must [Bm]go for what you wanted
+Look at a[G]ll my friends who d[A]id and got what they [G]deserved[D]   [Em/D]
+
+[G]So much [A]time to make up [D]everywhere you turn
+[G]Time we have [A]wasted on the way   [D]     [D7]
+[G]       S[A]o much water [D]moving underneath [Bm]the bridge
+Let the [G]water come and [A]carry us awa[D]y  [D7]
+
+[D]  [G]So much [A]love to make up [D]everywhere you turn
+[G]Love we have [A]wasted on the way   [F#m]     [D7]
+[G]So much [A]water moving [D]underneath the bri[Bm]dge
+Let the [G]water come and [A]carry us awa[G]y
+[D]  Let the [G]water come and [A]carry us awa[G]y   --    [D]
+#
+#______________________|_______________________________________________________
+#   ___                | Phil Bearce at Hewlett Packard San Jose - Components
+#  (/__) /_   .  /)    | internet: phil@hpmsfpb.sj.hp.com
+#  /    /  )_(__(_ --  | "I feel like complete shit, Ferris"  Cameron Fry
+#______________________|_______________________________________________________                                

--- a/songs/we_can_work_it_out.cho
+++ b/songs/we_can_work_it_out.cho
@@ -1,0 +1,52 @@
+
+{t:We Can Work it Out}
+{st:the Beatles}
+
+{comment:Capo 2nd fret to play like album track}
+
+[C]Try to see it my way.
+[C]Do I have to keep on talking
+[Bb]til I can't go [C]on?
+[C]While you see it your way,
+[C]run the risk of knowing that our
+[Bb]love may soon be [C]gone.
+[F]We can work it [C]out, [F]we can work it [G]out.
+
+[C]Think of what you're saying.
+[C]You can get it wrong and still you
+[Bb]think that it's al[C]right.
+[C]Think of what I'm saying.
+[C]We can work it out and get it
+[Bb]straight or say good[C]night
+[F]We can work it [C]out, [F]we can work it [G] out.
+
+[Am]Life is very short and there's no [F]ti-[E]me
+For fussing and
+(tempo change) [Am]fighting my friend. (change back)
+[Am]I have always thought that it's a [F]cri-[E]me
+So I will
+(tempo change) [Am] ask you once again. (change back)
+{colb}
+[C]Try to see it my way.
+[C]Only time will tell if I am [Bb]right or I am [C]wrong.
+[C]While you see it your way,
+[C]There's a chance that we might fall
+[Bb]apart before too [C]long.
+[F]We can work it [C]out, [F]we can work it [G]out.
+
+[Am]Life is very short and there's no [F]ti-[E]me
+For fussing and
+(tempo change) [Am]fighting my friend. (change back)
+[Am]I have always thought that it's a [F]cri-[E]me
+So I will
+(tempo change) [Am]ask you once again. (change back)
+
+[C]Try to see it my way.
+[C]Only time will tell if I am [Bb]right or I am [C]wrong.
+[C]While you see it your way,
+[C]There's a chance that we might fall
+[Bb]apart before too [C]long.
+[F]We can work it [C]out, [F]we can work it [G]out.
+
+{comment: accordion over C for outro}
+

--- a/songs/wish_it_would_rain.cho
+++ b/songs/wish_it_would_rain.cho
@@ -1,0 +1,58 @@
+{t:I Wish It Would Rain}
+{st:Nanci Griffith}
+# Tabs by Mandy G. 
+# P.S. This is the first song I ever learned to play, so it's perfect for all us beginners. Plus it's gorgeous.  Learn it... It's easy and fun.
+
+{comment:Capo 2}
+
+{define: G(9) 0 3 2 0 3 3}
+
+Chorus:
+[G]Oh, I wish it would rain
+wash my f[G(9)]ace cl[G]ean 
+
+I wanna find some dark clouds
+to hide in h[D]ere
+Oh, the love in a m[G]emory
+It sparkles like [G(9)]diamo[G]nds
+
+When the diamonds fall
+[D]They burn like t[Em-C]ears
+When the diamonds [G]fall
+[D]They burn like tears.
+
+[G]Once I had a love from the G[G(9)]eorgia p[G]ines
+who o[D]nly cared for [Em]me
+I wanna f[C]ind that love of [G]22
+here at [D]33
+[G]I Got a heart on my right and [G(9)]one on my l[G]eft
+but n[D]either suits my n[Em]eeds
+Cause the o[C]ne I love is w[G]ay out west
+and he n[D]ever will need me.
+
+(Chorus)
+{colb}
+[G]Gonna pack up my [G(9)]two-steppin' [G]shoes
+[D]and head for the Gulf Coast [Em]plains
+I wann[C]a walk the streets of my old hometown
+Where e[D]verybody knows my name
+[G]Gonna ride the waves down to [G(9)]Galvas[G]ton
+[D]When the hurricanes blow [Em]in
+Cause that [C]Gulf Coast water tastes sweet as wine
+when your [D]heart's blowin home in the [G]wind
+
+[G]And I wish it would rain
+wash my f[G(9)]ace cl[G]ean 
+
+I wanna find some dark clouds
+to hide in [D]here
+Oh, the love in a m[G]emory
+Sparkles like [G(9)]diamo[G]nds
+
+When the diamonds fall
+[D]They burn like t[Em-C]ears
+When the diamonds [G]fall
+[D]They burn like t[Em-C]ears
+When the diamonds [G]fall, darlin',
+[D]They burn like tears.
+

--- a/songs/wish_you_were_here.cho
+++ b/songs/wish_you_were_here.cho
@@ -1,0 +1,21 @@
+{t:Wish You Were Here}
+{st:Pink Floyd}
+#Added to UG By Mikhailo (mikhailo_@mail.ru)
+
+[C]So, so you think you can t[D]ell,
+Heaven from H[Am]ell, blue skies from [G]pain.
+Can you tell a green [D]field from a cold steel [C]rail, a smile from a [Am]veil,
+Do you think you can t[G]ell?
+
+And did they get you to tr[C]ade your heroes for [D]ghosts,
+Hot ashes for tr[Am]ees, hot air for a coo[G]l breeze, cold comfort for cha[D]nge,
+And did you exchan[C]ge a walk on part in the [Am]war for a lead role in a ca[G]ge?
+
+[Em]    [G]   [Em]    [G]   [Em]    [A]   [Em]    [A]
+
+[C]How I wish, how I wish you were [D]here.
+We're just [Am]two lost souls swimming in a fish bow[G]l, year after year,  [D]
+Running over the same old ground. [C]What have we found?
+The same old [Am]fears. Wish you were here! [G]
+
+[Em]    [G]   [Em]    [G]   [Em]    [A]   [Em]    [A]   [G]

--- a/songs/with_a_little_help_from_my_friends.cho
+++ b/songs/with_a_little_help_from_my_friends.cho
@@ -1,0 +1,53 @@
+
+{t:With a Little Help from My Friends}
+{st:the Beatles}
+
+{comment: Capo on 4th fret}
+
+[C]What would think [G]do if I [Dm]sang out of tune?
+Would you stand up and [G7]walk out on [C]me?
+[C]Lend me your [G]ears and I'll [Dm]sing you a song,
+and I'll try not to [G7]sing out of [C]key.
+
+Oh, I get [Bb]by with a little [F]help from my [C]friends.
+Mm, I get [Bb]high with a little [F]help from my [C]friends.
+Mm, I'm gonna [Bb]try with a little [F]help from my [C]friends.
+
+(tiny [G] riff)
+
+[C]What do I [G]do when my [Dm]love is away.
+(others) [Dm]Does it worry you to [G7]be a[C]lone?
+[C]How do I [G]feel at the [Dm]end of the day?
+(others) [Dm]Are you sad because you're [G7]on your [C]own?
+
+No, I get [Bb]by with a little [F]help from my [C]friends.
+Mm, get [Bb]high with a little [F]help from my [C]friends.
+Mm, gonna [Bb]try with a little [F]help from my [C]friends.
+
+[C]Do you [Am]need any[D7]body?
+I [C]need some[Bb]body to [F]love
+[F]Could it [Am]be any[D7]body?
+I [C]want some[Bb]body to [F]love
+
+(others) [C]Would you [G]believe in a [Dm]love at first sight?
+Yes, I'm certain that it [G7]happens all the [C]time.
+(others) [C]What you do [G]see when you [Dm]turn out the light?
+I can't tell you but I [G7]know it's [C]mine.
+
+{colb}
+
+Oh, I get [Bb]by with a little [F]help from my [C]friends.
+Mm, I get [Bb]high with a little [F]help from my [C]friends.
+Oh, I'm gonna [Bb]try with a little [F]help from my [C]friends.
+
+[C]Do you [Am]need any[D7]body?
+I [C]just need[Bb]someone to [F]love
+[F]Could it [Am]be any[D7]body?
+I [C]want some[Bb]body to [F]love
+
+Oh, I get [Bb]by with a little [F]help from my [C]friends.
+Oo, I get [Bb]high with a little [F]help from my [C]friends.
+Yes, I get [Bb]by with a little help from my [F]friends,
+with a little help from my [Ab]friiii[Bb]eeeends.[C]
+
+

--- a/songs/wonderwall.cho
+++ b/songs/wonderwall.cho
@@ -1,0 +1,97 @@
+
+{even}
+{t:Wonderwall}
+{st:Oasis}
+
+{define: Em7 0 2 2 0 3 3}
+{define: G 3 2 0 0 3 3}
+{define: Dsus4 x x 0 2 3 3}
+{define: A7sus4 x 0 2 0 3 3}
+{define: Cadd9 x 3 2 0 3 3}
+
+INTRO:
+
+[Em7] [G] [Dsus4] [A7sus4]  [x4]
+
+VERSE 1:
+
+[Em7]Today is [G]gonna be the day that they're
+[Dsus4]gonna throw it back to [A7sus4]you
+[Em7]By now you [G]should've somehow
+rea[Dsus4]lized what you gotta [A7sus4]do
+[Em7]I don't believe that [G]anybody
+[Dsus4]feels the way I [A7sus4]do,
+About you [Cadd9]now [Dsus4] [A7sus4]
+
+VERSE 2:
+
+[Em7]Backbeat the [G]word is on the street that the
+[Dsus4]fire in your heart is [A7sus4]out
+[Em7]I'm sure you've [G]heard it all before but you
+[Dsus4]never really had a [A7sus4]doubt
+[Em7]I don't believe that [G]anybody
+[Dsus4]feels the way I [A7sus4]do,
+about you [Cadd9]now [Dsus4] [A7sus4]
+
+{colb}
+PRE-CHORUS:
+
+And [Cadd9]all the roads we
+[Dsus4]have to walk are [Em7]winding
+And [Cadd9]all the lights that
+[Dsus4]lead us there are [Em7]blinding
+[Cadd9]There are many [Dsus4]things that I
+Would [G]like to [Dsus4]say to [Em7]you,
+but I [Dsus4]don't know [A7sus4]how
+
+CHORUS:
+
+Cause [Cadd9]maybe [Em7] [G]
+You're gonna [Em7]be the one that
+[Cadd9]saves me? [Em7] [G]
+And [Em7]after [Cadd9]all [Em7]
+[G] You're my [Em7]wonder
+[Cadd9]wall [Em7] [G] [Em7] [Silence]
+
+
+VERSE 3:
+
+[Em7]Today is [G]gonna be the day but they'll
+[Dsus4]never throw it back to [A7sus4]you
+[Em7]By now you [G]should've somehow
+rea[Dsus4]lized what you're not to [A7sus4]do
+[Em7]I don't believe that [G]anybody
+[Dsus4]feels the way I [A7sus4]do,
+about you [Cadd9]now [Dsus4] [A7sus4]
+
+{colb}
+PRE-CHORUS:
+
+And [Cadd9]all the roads that
+[Dsus4]lead you there are [Em7]winding
+And [Cadd9]all the lights that
+[Dsus4]light the way are [Em7]blinding
+[Cadd9]There are many [Dsus4]things that I
+Would [G]like to [Dsus4]say to [Em7]you,
+but I [Dsus4]don't know [A7sus4]how
+
+CHORUS:
+
+Cause [Cadd9]maybe [Em7] [G]
+[Em7]you're gonna be the one that
+[Cadd9]saves me? [Em7] [G]
+And [Em7]after [Cadd9]all [Em7]
+[G]You're my [Em7]wonder
+[Cadd9]wall [Em7] [G] [Em7]
+
+CHORUS: x2
+
+SOLO:
+
+{sot}
+G|---------0-----|
+D|------------2--|   8 times
+A|--3-2-3--------|
+E|---------------|
+{eot}
+

--- a/songs/yer_so_bad.cho
+++ b/songs/yer_so_bad.cho
@@ -1,0 +1,30 @@
+{t:Yer So Bad}
+{st:Tom Petty}
+
+[Am]My sister got [D]lucky
+[G]Married a [Am]yuppie
+[Am]took him for [D]all he was [G]worth
+[Am]now she's a [D]swinger
+[G]dating a [Am]singer
+[Am]I can't d[D]ecide which is [G]worse
+
+
+chorus
+But [Em]not -- [C]me -- [G]ba[D]by
+I got [Em]you -- [C]to -- [G]save -- [D]me
+[G]You're [D]so [C]bad
+[G]best thing [D]I ever [C]had.
+In a [G]world [D]gone [C]mad
+[G]you're [D]so [C]bad    [D]
+
+{colb}
+[Am]My sister's [D]ex-husband
+[G]can't get no [Am]loving
+[Am]walks around [D]dog-faced and [G]hurt
+[Am]now he's got [D]nothing
+[G]head's in the [Am]oven
+[Am]I can't [D]decide which is [G]worse
+
+chorus
+
+[G]  [G]  [C]  [C]  [G]  [G]  [G]

--- a/songs/zombie_cranberries.cho
+++ b/songs/zombie_cranberries.cho
@@ -1,0 +1,48 @@
+{t:Zombie}
+{st:The Cranberries}
+
+{define: D/F# 2 0 0 0 0 3}
+
+Intro(x4): [Em] [C] [G] [D/F#]
+
+[Em]Another he[C]ad hangs lowly,
+Chi[G]ld is slowly ta[D/F#]ken
+And the [Em]violence ca[C]used such silence.
+[G]Who are we mista[D/F#]ken
+But you [Em]see, it's not me,
+it's not [C]my family.
+In your [G]head, in your head,
+they are figh[D/F#]ting
+
+With their [Em]tanks, and their bombs,
+and their [C]bombs, and their guns
+In your [G]head, in your head they are cr[D/F#]yin'
+
+In your [Em]head, In your [C]head,
+Zom[G]bie, Zombie, Zom[D/F#]bie, ie, ie
+What's in your [Em]head in your [C]head,
+Zom[G]bie, Zombie, Zom[D/F#]bie, ie, ie, ie
+[Em]Ooh do do do do do [C]do do do do do
+[G]do do do do do [D/F#]do do do do do
+
+{colb}
+[Em]Another [C]mother's breakin'
+[G]heart is taking o[D/F#]ver
+When the [Em]violence ca[C]uses silence
+[G]we must be mista[D/F#]ken
+It's the [Em]same old theme since [C]1916,
+in your [G]head, in your head they're still figh[D/F#]tin'
+
+With their [Em]tanks, and their bombs,
+and their [C]bombs, and their guns
+In your [G]head, in your head they are dy[D/F#]ing
+
+In your [Em]head, In your [C]head,
+Zom[G]bie, Zombie, Zom[D/F#]bie, ie, ie
+What's in your [Em]head in your [C]head,
+Zom[G]bie, Zombie, Zom[D/F#]bie, ie, ie, ie
+[Em]Ooh oh oh oh [C]oh oh oh oh
+[G]ah ah-ye-ah [D/F#]ah
+
+Outro(x4): [Em] [C] [G] [D/F#]
+


### PR DESCRIPTION
## Summary
- Convert HTML-embedded song sources into raw ChordPro `.cho` files
- Simplify Makefile to build HTML and PDF via `chordpro` CLI, including a combined `kc_songbook.pdf`
- Update README for one-step `make` workflow

## Testing
- `make kc_songbook.pdf 2>&1 | head -n 20` *(fails: chordpro: No such file or directory)*

------
https://chatgpt.com/codex/tasks/task_e_688fe8184074832195cf8245923c5fee